### PR TITLE
Switch the default formatter to ormolu

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
             "stylish-haskell",
             "none"
           ],
-          "default": "brittany",
+          "default": "ormolu",
           "description": "The tool to use for formatting requests"
         },
         "haskell.trace.server": {


### PR DESCRIPTION

Since brittany isn't included in the static binaries due to licensing
restrictions
Fixes https://github.com/haskell/vscode-haskell/issues/255