### PR TITLE
Fix absolute paths not working on windows

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -160,7 +160,8 @@ function getWithRedirects(opts: https.RequestOptions, f: (res: http.IncomingMess
  * Checks if the executable is on the PATH
  */
 export function executableExists(exe: string): boolean {
-  const cmd: string = process.platform === 'win32' ? 'where' : 'which';
+  const isWindows = process.platform === 'win32';
+  const cmd: string = isWindows ? 'where' : 'which';
   const out = child_process.spawnSync(cmd, [exe]);
-  return out.status === 0;
+  return out.status === 0 || (isWindows && fs.existsSync(exe));
 }


### PR DESCRIPTION
I ran into "Manual executable missing" when trying to use an absolute `serverExecutablePath` on windows with:
```
"haskell.serverExecutablePath": "C:/path/to/hie_wrapper.exe", // "C:\\path\\to\\hie_wrapper.exe" didn't work either
```

I think the problem stems from the `where` command on windows not having the expected behavior when passed an absolute path:
```
C:\>where c:/Windows/System32/notepad.exe
ERROR: Invalid pattern is specified in "path:pattern".

C:\>where c:\Windows\System32\notepad.exe
ERROR: Invalid pattern is specified in "path:pattern".
```

The commit should solve this but it doesn't check for executable permissions so I was considering something like this:
```typescript
function absoluteExecutableExistsWindows(exe: string): boolean {
  try {
    fs.accessSync(exe, fs.constants.X_OK);
    return true;
  } except (e) {
    return false;
  }
}
export function executableExists(exe: string): boolean {
  const isWindows = process.platform === 'win32';
  const cmd: string = isWindows ? 'where' : 'which';
  const out = child_process.spawnSync(cmd, [exe]);
  return out.status === 0 || (isWindows && absoluteExecutableExistsWindows(exe));
}
```
but according to https://nodejs.org/api/fs.html#fs_file_access_constants and https://nodejs.org/api/fs.html#fs_fs_accesssync_path_mode , it's not required.

I'm happy to make any suggested/required changes to this PR and thanks for looking at this!