### PR TITLE
Fix the haskell-language-server path table in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,12 @@ its dependencies have been built with the `-haddock` GHC flag.
 ### Downloaded binaries
 
 This extension will download `haskell-language-server` binaries to a specific location depending on your system. If you find yourself running out of disk space, you can try deleting old versions of language servers in this directory. The extension will redownload them, no strings attached.
-| Platform | Path |
-|----------|------|
-| macOS | `~/Library/Application\ Support/Code/User/globalStorage/haskell.haskell/` |
-| Windows | `%APPDATA%\Code\User\globalStorage\haskell.haskell` |
-| Linux | `$HOME/.config/Code/User/globalStorage/haskell.haskell` |
+
+| Platform | Path                                                                      |
+|----------|---------------------------------------------------------------------------|
+| macOS    | `~/Library/Application\ Support/Code/User/globalStorage/haskell.haskell/` |
+| Windows  | `%APPDATA%\Code\User\globalStorage\haskell.haskell`                       |
+| Linux    | `$HOME/.config/Code/User/globalStorage/haskell.haskell`                   |
 
 Note that if `haskell-language-server-wrapper`/`haskell-language-server` is already on the PATH, then the extension will launch it directly instead of downloading binaries.
 


### PR DESCRIPTION
Hey!

I noticed that the table for the haskell language server Path location on each platform was rendered incorrectly in the visual studio marketplace. It shows as:

> This extension will download haskell-language-server binaries to a specific location depending on your system. If you find yourself running out of disk space, you can try deleting old versions of language servers in this directory. The extension will redownload them, no strings attached. | Platform | Path | |----------|------| | macOS | ~/Library/Application\ Support/Code/User/globalStorage/haskell.haskell/ | | Windows | %APPDATA%\Code\User\globalStorage\haskell.haskell | | Linux | $HOME/.config/Code/User/globalStorage/haskell.haskell |

I suspect the the extra new line before the table will fix this given that I have had this issue before and the other table for GHC versions, which has the extra new line, is rendered correctly.

Let me know if there is anything else! Thanks!