### PR TITLE
Remove the haskell.enable configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,6 @@ You can choose which language server to use from the "Haskell > Language Server 
 
 ## Configuration options
 
-### Enable/disable server
-
-You can enable or disable the chosen haskell language server via configuration. This is sometimes useful at workspace level, because multi-root workspaces do not yet allow you to manage extensions at the folder level, which can be necessary.
-
-```json
-"haskell.enable": true
-```
-
 ### Path to server executable executable
 
 If your server is manually installed and not on your path, you can also manually set the path to the executable.

--- a/package.json
+++ b/package.json
@@ -150,12 +150,6 @@
           "type": "string",
           "default": "",
           "description": "Manually set a language server executable. Can be something on the $PATH or a path to an executable itself. Works with ~, ${HOME} and ${workspaceFolder}."
-        },
-        "haskell.enable": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": true,
-          "description": "Enable/disable the language server (useful for multi-root workspaces)."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -139,12 +139,6 @@ async function activateServerForFolder(context: ExtensionContext, uri: Uri, fold
   // Set the key to null to prevent multiple servers being launched at once
   clients.set(clientsKey, null);
 
-  // Stop right here, if Haskell is disabled in the resource/workspace folder.
-  const enable = workspace.getConfiguration('haskell', uri).enable;
-  if (!enable) {
-    return;
-  }
-
   const logLevel = workspace.getConfiguration('haskell', uri).trace.server;
   const logFile = workspace.getConfiguration('haskell', uri).logFile;
 


### PR DESCRIPTION

It doesn't seem to be needed anymore now that VS Code provides ways of
disabling extensions on a per-workspace basis natively

Closes #268