### PR TITLE
Show docs as docs, not as sources on Windows too

### DIFF
--- a/src/docsBrowser.ts
+++ b/src/docsBrowser.ts
@@ -85,11 +85,13 @@ export namespace DocsBrowser {
 
   function processLink(ms: MarkedString): string | MarkdownString {
     function transform(s: string): string {
-      return s.replace(/\[(.+)\]\((file:.+\/doc\/.+\.html#?.*)\)/gi, (all, title, path) => {
-        const encoded = encodeURIComponent(JSON.stringify({ title, path }));
-        const cmd = 'command:haskell.showDocumentation?' + encoded;
-        return `[${title}](${cmd})`;
-      });
+      // normalize slashes from windows paths and replace file url with show doc command
+      return s.replace(/\\/gi, '/')
+        .replace(/\[(.+)\]\((file:.+\/doc\/.+\.html#?.*)\)/gi, (all, title, path) => {
+          const encoded = encodeURIComponent(JSON.stringify({ title, path }));
+          const cmd = 'command:haskell.showDocumentation?' + encoded;
+          return `[${title}](${cmd})`;
+        });
     }
     if (typeof ms === 'string') {
       return transform(ms as string);


### PR DESCRIPTION
Normalize slashes in file URLs to correctly show docs on Windows.

Compliments haskell/vscode-haskell/pull/21

**Before:**

![image](https://user-images.githubusercontent.com/5116838/88658438-8f84db80-d127-11ea-9aa3-2a6dec7326b6.png)

**After:**

![image](https://user-images.githubusercontent.com/5116838/89388575-52889c80-d758-11ea-8fa8-7a6d83fbf793.png)


There's also related bug on HLS end haskell/haskell-language-server/issues/247 (trivial to fix, will submit soon)

Or do you think it's better to normalize slashes in all paths on HLS end? I'm not sure how easy it is to pinpoint all paths' origins there, also other plugins are potentially affected (ghcide, hie).