### PR TITLE
Use local files on connection failure, closes #298

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,20 @@
           "type": "string",
           "default": "",
           "description": "Manually set a language server executable. Can be something on the $PATH or a path to an executable itself. Works with ~, ${HOME} and ${workspaceFolder}."
+        },
+        "haskell.hlsUpdateBehavior": {
+          "scope": "machine",
+          "type": "string",
+          "enum": [
+            "keep-up-to-date",
+            "prompt"
+          ],
+          "enumDescriptions": [
+            "Always download the latest available version when it is published",
+            "Prompt before downloading a newer version"
+          ],
+          "default": true,
+          "markdownDescription": "Only applicable with `#haskell.languageServerVariant#` set to `haskell-language-server`. Determine what to do when a new version of the language server is available."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -157,13 +157,15 @@
           "type": "string",
           "enum": [
             "keep-up-to-date",
-            "prompt"
+            "prompt",
+            "never-check"
           ],
           "enumDescriptions": [
             "Always download the latest available version when it is published",
-            "Prompt before downloading a newer version"
+            "Prompt before upgrading to a newer version",
+            "Don't check for newer versions"
           ],
-          "default": true,
+          "default": "keep-up-to-date",
           "markdownDescription": "Only applicable with `#haskell.languageServerVariant#` set to `haskell-language-server`. Determine what to do when a new version of the language server is available."
         }
       }

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
           "default": "",
           "description": "Manually set a language server executable. Can be something on the $PATH or a path to an executable itself. Works with ~, ${HOME} and ${workspaceFolder}."
         },
-        "haskell.hlsUpdateBehavior": {
+        "haskell.updateBehavior": {
           "scope": "machine",
           "type": "string",
           "enum": [

--- a/src/hlsBinaries.ts
+++ b/src/hlsBinaries.ts
@@ -180,7 +180,7 @@ async function getLatestReleaseMetadata(context: ExtensionContext): Promise<IRel
     }
   }
   // Not all users want to upgrade right away, in that case prompt
-  const updateBehaviour = workspace.getConfiguration('haskell').get('hlsUpdateBehavior') as UpdateBehaviour;
+  const updateBehaviour = workspace.getConfiguration('haskell').get('updateBehavior') as UpdateBehaviour;
 
   if (updateBehaviour === 'never-check') {
     return readCachedReleaseData();
@@ -253,7 +253,7 @@ export async function downloadHaskellLanguageServer(
   const release = await getLatestReleaseMetadata(context);
   if (!release) {
     let message = "Couldn't find any pre-built haskell-language-server binaries";
-    const updateBehaviour = workspace.getConfiguration('haskell').get('hlsUpdateBehavior') as UpdateBehaviour;
+    const updateBehaviour = workspace.getConfiguration('haskell').get('updateBehavior') as UpdateBehaviour;
     if (updateBehaviour === 'never-check') {
       message += ' (and checking for newer versions is disabled)';
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,7 @@ import { createGunzip } from 'zlib';
 /** When making http requests to github.com, use this header otherwise
  * the server will close the request
  */
-export const userAgentHeader = { 'User-Agent': 'vscode-haskell' };
+const userAgentHeader = { 'User-Agent': 'vscode-haskell' };
 
 /** downloadFile may get called twice on the same src and destination:
  * When this happens, we should only download the file once but return two
@@ -26,6 +26,29 @@ export const userAgentHeader = { 'User-Agent': 'vscode-haskell' };
  * [src, dest] as the key.
  */
 const inFlightDownloads = new Map<string, Map<string, Thenable<void>>>();
+
+export async function httpsGetSilently(options: https.RequestOptions): Promise<string> {
+  const opts: https.RequestOptions = {
+    ...options,
+    headers: {
+      ...(options.headers ?? {}),
+      ...userAgentHeader,
+    },
+  };
+
+  return new Promise((resolve, reject) => {
+    let data: string = '';
+    https
+      .get(opts, (res) => {
+        res.on('data', (d) => (data += d));
+        res.on('error', reject);
+        res.on('close', () => {
+          resolve(data);
+        });
+      })
+      .on('error', reject);
+  });
+}
 
 export async function downloadFile(titleMsg: string, src: string, dest: string): Promise<void> {
   // Check to see if we're already in the process of downloading the same thing

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -24,6 +24,7 @@ function success<T>(t: T): ValidationResult<T> {
     value: t,
   };
 }
+
 function failure<T>(errors: IValidationError[]): ValidationResult<T> {
   return {
     success: false,
@@ -100,33 +101,24 @@ export function object<S>(schema: { [P in keyof S]: Validator<S[P]> }): Validato
     }
 
     if (!validationFailed) {
-      return {
-        success: true,
-        // when we get here, all properties in S have been validated and assigned, so
-        // this type assertion is okay.
-        value: scrutinee as { [P in keyof S]: S[P] },
-      };
+      // when we get here, all properties in S have been validated and assigned, so
+      // this type assertion is okay.
+      return success(scrutinee as { [P in keyof S]: S[P] });
     }
 
-    return {
-      success: false,
-      errors,
-    };
+    return failure(errors);
   };
 }
 
 export function array<S>(memberValidator: Validator<S>): Validator<S[]> {
   return (scrutinee) => {
     if (!(scrutinee instanceof Array)) {
-      return {
-        success: false,
-        errors: [
-          {
-            path: [],
-            message: 'expected an array',
-          },
-        ],
-      };
+      return failure([
+        {
+          path: [],
+          message: 'expected an array',
+        },
+      ]);
     }
 
     const errors: IValidationError[] = [];
@@ -147,26 +139,17 @@ export function array<S>(memberValidator: Validator<S>): Validator<S[]> {
     }
 
     if (!validationFailed) {
-      return {
-        success: true,
-        value: scrutinee,
-      };
+      return success(scrutinee);
     }
 
-    return {
-      success: false,
-      errors,
-    };
+    return failure(errors);
   };
 }
 
 export function optional<T>(validator: Validator<T>): Validator<T | null> {
   return (scrutinee) => {
     if (scrutinee === null) {
-      return {
-        success: true,
-        value: null,
-      };
+      return success(null);
     }
     return validator(scrutinee);
   };

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,0 +1,188 @@
+// Open for other validation libraries, but I haven't found any that were small enough,
+// strongly typed and maintained.
+
+export interface IValidationError {
+  path: PropertyKey[];
+  message: string;
+}
+
+export type ValidationResult<T> =
+  | {
+      success: true;
+      value: T;
+    }
+  | {
+      success: false;
+      errors: IValidationError[];
+    };
+
+export type Validator<T> = (scrutinee: unknown) => ValidationResult<T>;
+
+function success<T>(t: T): ValidationResult<T> {
+  return {
+    success: true,
+    value: t,
+  };
+}
+function failure<T>(errors: IValidationError[]): ValidationResult<T> {
+  return {
+    success: false,
+    errors,
+  };
+}
+
+function typeGuard<T>(name: string, guard: (arg: unknown) => arg is T): Validator<T> {
+  return (scrutinee) => {
+    if (guard(scrutinee)) {
+      return success(scrutinee);
+    }
+    return failure([
+      {
+        path: [],
+        message: `expected a ${name}`,
+      },
+    ]);
+  };
+}
+
+export function string(): Validator<string> {
+  function stringGuard(arg: unknown): arg is string {
+    return typeof arg === 'string';
+  }
+  return typeGuard('string', stringGuard);
+}
+
+export function boolean(): Validator<boolean> {
+  function boolGuard(arg: unknown): arg is boolean {
+    return typeof arg === 'boolean';
+  }
+  return typeGuard('boolean', boolGuard);
+}
+
+function hasOwnProperty<X extends {}, Y extends PropertyKey>(obj: X, prop: Y): obj is X & Record<Y, unknown> {
+  return obj.hasOwnProperty(prop);
+}
+
+export function object<S>(schema: { [P in keyof S]: Validator<S[P]> }): Validator<{ [P in keyof S]: S[P] }> {
+  return (scrutinee) => {
+    if (typeof scrutinee !== 'object' || scrutinee === null) {
+      return failure([
+        {
+          path: [],
+          message: 'expected an object',
+        },
+      ]);
+    }
+
+    const errors: IValidationError[] = [];
+    let validationFailed = false;
+    for (const key in schema) {
+      if (!schema[key]) {
+        continue;
+      }
+
+      // If the deserialized value doesn't have the key, use `undefined` as a placeholder
+      // might get replaced with a default value
+      const existingSub = hasOwnProperty(scrutinee, key) ? scrutinee[key] : undefined;
+      const subResult = schema[key](existingSub);
+
+      if (subResult.success) {
+        Object.assign(scrutinee, { [key]: subResult.value });
+      } else {
+        subResult.errors.forEach((val) =>
+          errors.push({
+            path: [key, ...val.path],
+            message: val.message,
+          })
+        );
+        validationFailed = true;
+      }
+    }
+
+    if (!validationFailed) {
+      return {
+        success: true,
+        // when we get here, all properties in S have been validated and assigned, so
+        // this type assertion is okay.
+        value: scrutinee as { [P in keyof S]: S[P] },
+      };
+    }
+
+    return {
+      success: false,
+      errors,
+    };
+  };
+}
+
+export function array<S>(memberValidator: Validator<S>): Validator<S[]> {
+  return (scrutinee) => {
+    if (!(scrutinee instanceof Array)) {
+      return {
+        success: false,
+        errors: [
+          {
+            path: [],
+            message: 'expected an array',
+          },
+        ],
+      };
+    }
+
+    const errors: IValidationError[] = [];
+    let validationFailed = false;
+    for (let i = 0; i < scrutinee.length; ++i) {
+      const subResult = memberValidator(scrutinee[i]);
+      if (subResult.success) {
+        scrutinee[i] = subResult.value;
+      } else {
+        subResult.errors.forEach((val) =>
+          errors.push({
+            path: [i, ...val.path],
+            message: val.message,
+          })
+        );
+        validationFailed = true;
+      }
+    }
+
+    if (!validationFailed) {
+      return {
+        success: true,
+        value: scrutinee,
+      };
+    }
+
+    return {
+      success: false,
+      errors,
+    };
+  };
+}
+
+export function optional<T>(validator: Validator<T>): Validator<T | null> {
+  return (scrutinee) => {
+    if (scrutinee === null) {
+      return {
+        success: true,
+        value: null,
+      };
+    }
+    return validator(scrutinee);
+  };
+}
+
+export class ValidationError extends Error {
+  constructor(public errors: IValidationError[], message?: string) {
+    super(`validation failure: ${errors.length} errors`);
+  }
+}
+
+export function parseAndValidate<T>(text: string, validator: Validator<T>): T {
+  const value: unknown = JSON.parse(text);
+  const result = validator(value);
+  if (result.success) {
+    return result.value;
+  }
+  throw new ValidationError(result.errors);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "rootDir": ".",
     "noUnusedLocals": true,
     "strict": true,
+    "noImplicitAny": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "strictNullChecks": true


### PR DESCRIPTION
Use already downloaded tools when fetching latest release metadata fails. This adds a small cache file in the `globalStoragePath` containing the last fetched information.

Does not currently implement the feature as requested in #281 as I'm not certain what exactly such a flag should do (pick one):
- Not download anything at all
- `"haskell.hlsUpdateBehavior": "keep-up-to-date"` Try to fetch latest release information, if that fails fall back to local cache (what is done with this PR automatically)
- `"haskell.hlsUpdateBehavior": "prompt"` Try to fetch latest release information, but not upgrade, even if it succeeds and instead display a prompt to update (probably sensible), still download artifacts for the proper ghc version, if necessary.
- `"haskell.hlsUpdateBehavior": "never-check"` Don't check for latest release information, and do not upgrade, but still download artifacts for missing ghc versions, if needed.

I would want to implement #281 in this PR if that behavior is cleared up for me :)