### PR TITLE
add "Reopen on Hackage (beta)" hyperlink to doc window

### DIFF
--- a/src/docsBrowser.ts
+++ b/src/docsBrowser.ts
@@ -43,7 +43,7 @@ export namespace DocsBrowser {
           const encoded = encodeURIComponent(JSON.stringify({ hackageUri }));
           const hackageCmd = 'command:haskell.openDocumentationOnHackage?' + encoded;
 
-          panel.webview.html = `<div><a href="${hackageCmd}">Reopen on Hackage (beta)</a></div>
+          panel.webview.html = `<div><a href="${hackageCmd}">Reopen on Hackage</a></div>
           <div><iframe src="${uri}" frameBorder = "0" style = "background: white; width: 100%; height: 100%; position:absolute; left: 0; right: 0; bottom: 0; top: 30px;"/></div>`;
         } catch (e) {
           await window.showErrorMessage(e);

--- a/src/docsBrowser.ts
+++ b/src/docsBrowser.ts
@@ -6,6 +6,7 @@ import {
   CompletionItem,
   CompletionList,
   Disposable,
+  env,
   Hover,
   MarkdownString,
   MarkedString,
@@ -23,24 +24,48 @@ export namespace DocsBrowser {
 
   // registers the browser in VSCode infrastructure
   export function registerDocsBrowser(): Disposable {
-    return commands.registerCommand('haskell.showDocumentation', ({ title, path }: { title: string; path: string }) => {
-      const arr = path.match(/([^\/]+)\.[^.]+$/);
-      const ttl = arr !== null && arr.length === 2 ? arr[1].replace(/-/gi, '.') : title;
-      const documentationDirectory = dirname(path);
-      let panel;
-      try {
-        // Make sure to use Uri.parse here, as path will already have 'file:///' in it
-        panel = window.createWebviewPanel('haskell.showDocumentationPanel', ttl, ViewColumn.Beside, {
-          localResourceRoots: [Uri.parse(documentationDirectory)],
-          enableFindWidget: true,
-        });
-        const uri = panel.webview.asWebviewUri(Uri.parse(path));
-        panel.webview.html = `<iframe src="${uri}" frameBorder = "0" style = "background: white; width: 100%; height: 100%; position:absolute; left: 0; right: 0; bottom: 0; top: 0px;" /> `;
-      } catch (e) {
-        window.showErrorMessage(e);
+    return commands.registerCommand(
+      'haskell.showDocumentation',
+      async ({ title, localPath, hackageUri }: { title: string; localPath: string; hackageUri: string }) => {
+        const arr = localPath.match(/([^\/]+)\.[^.]+$/);
+        const ttl = arr !== null && arr.length === 2 ? arr[1].replace(/-/gi, '.') : title;
+        const documentationDirectory = dirname(localPath);
+        let panel;
+        try {
+          // Make sure to use Uri.parse here, as path will already have 'file:///' in it
+          panel = window.createWebviewPanel('haskell.showDocumentationPanel', ttl, ViewColumn.Beside, {
+            localResourceRoots: [Uri.parse(documentationDirectory)],
+            enableFindWidget: true,
+            enableCommandUris: true,
+          });
+          const uri = panel.webview.asWebviewUri(Uri.parse(localPath));
+
+          const encoded = encodeURIComponent(JSON.stringify({ hackageUri }));
+          const hackageCmd = 'command:haskell.openDocumentationOnHackage?' + encoded;
+
+          panel.webview.html = `<div><a href="${hackageCmd}">Reopen on Hackage (beta)</a></div>
+          <div><iframe src="${uri}" frameBorder = "0" style = "background: white; width: 100%; height: 100%; position:absolute; left: 0; right: 0; bottom: 0; top: 30px;"/></div>`;
+        } catch (e) {
+          await window.showErrorMessage(e);
+        }
+        return panel;
       }
-      return panel;
-    });
+    );
+  }
+
+  export function registerDocsOpenOnHackage(): Disposable {
+    return commands.registerCommand(
+      'haskell.openDocumentationOnHackage',
+      async ({ hackageUri }: { hackageUri: string }) => {
+        try {
+          // open on Hackage and close the original webview in VS code
+          await env.openExternal(Uri.parse(hackageUri));
+          await commands.executeCommand('workbench.action.closeActiveEditor');
+        } catch (e) {
+          await window.showErrorMessage(e);
+        }
+      }
+    );
   }
 
   export function hoverLinksMiddlewareHook(
@@ -85,11 +110,18 @@ export namespace DocsBrowser {
 
   function processLink(ms: MarkedString): string | MarkdownString {
     function transform(s: string): string {
-      return s.replace(/\[(.+)\]\((file:.+\/doc\/.+\.html#?.*)\)/gi, (all, title, path) => {
-        const encoded = encodeURIComponent(JSON.stringify({ title, path }));
-        const cmd = 'command:haskell.showDocumentation?' + encoded;
-        return `[${title}](${cmd})`;
-      });
+      return s.replace(
+        /\[(.+)\]\((file:.+\/doc\/(?:html\/libraries\/)?([^\/]+)\/(src\/)?(.+\.html#?.*))\)/gi,
+        (all, title, localPath, packageName, maybeSrcDir, fileAndAnchor) => {
+          if (!maybeSrcDir) {
+            maybeSrcDir = '';
+          }
+          const hackageUri = `https://hackage.haskell.org/package/${packageName}/docs/${maybeSrcDir}${fileAndAnchor}`;
+          const encoded = encodeURIComponent(JSON.stringify({ title, localPath, hackageUri }));
+          const cmd = 'command:haskell.showDocumentation?' + encoded;
+          return `[${title}](${cmd})`;
+        }
+      );
     }
     if (typeof ms === 'string') {
       return transform(ms as string);

--- a/src/docsBrowser.ts
+++ b/src/docsBrowser.ts
@@ -111,7 +111,7 @@ export namespace DocsBrowser {
   function processLink(ms: MarkedString): string | MarkdownString {
     function transform(s: string): string {
       return s.replace(
-        /\[(.+)\]\((file:.+\/doc\/(?:html\/libraries\/)?([^\/]+)\/(src\/)?(.+\.html#?.*))\)/gi,
+        /\[(.+)\]\((file:.+\/doc\/(?:.*html\/libraries\/)?([^\/]+)\/(src\/)?(.+\.html#?.*))\)/gi,
         (all, title, localPath, packageName, maybeSrcDir, fileAndAnchor) => {
           if (!maybeSrcDir) {
             maybeSrcDir = '';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -65,6 +65,9 @@ export async function activate(context: ExtensionContext) {
   // Set up the documentation browser.
   const docsDisposable = DocsBrowser.registerDocsBrowser();
   context.subscriptions.push(docsDisposable);
+
+  const openOnHackageDisposable = DocsBrowser.registerDocsOpenOnHackage();
+  context.subscriptions.push(openOnHackageDisposable);
 }
 
 function findManualExecutable(uri: Uri, folder?: WorkspaceFolder): string | null {


### PR DESCRIPTION


As suggested in abandoned PR #295 , tried to translate local file to the Hackage URL as it's more reliable and doesn't need extra dependencies.

Click to open in browser and close the original tab.  Tested only on Windows but Mac or Linux should work too.

![image](https://user-images.githubusercontent.com/5116838/95317206-58823180-08f1-11eb-8cb3-3f460e4f90b7.png)

Also can provide option to open on hackage straight away bypassing the VS code tab, although not confident if translation works in 100% of cases.

**Examples:**

**GHC libraries doc**
	* Local: file:///C:/Users/KolA/AppData/Local/Programs/stack/x86_64-windows/ghc-8.6.5/doc/html/libraries/base-4.12.0.0/GHC-Maybe.html#t:Maybe
	* Hackage: https://hackage.haskell.org/package/base-4.12.0.0/docs/GHC-Maybe.html#t:Maybe

**GHC libraries src doc**
	* N/A

**stackage snapshot doc:**
	* Local: file:///C:/sr/snapshots/b84f27c3/doc/haskell-lsp-types-0.22.0.0/Language-Haskell-LSP-Types.html#t:NormalizedFilePath
	* Hackage: https://hackage.haskell.org/package/haskell-lsp-types-0.22.0.0/docs/Language-Haskell-LSP-Types.html#t:NormalizedFilePath

**stackage snapshot src doc**
	* Local: file:///C:/sr/snapshots/4fa1b8a7/doc/unordered-containers-0.2.10.0/src/Data.HashMap.Base.html#lookup
	* Hackage: https://hackage.haskell.org/package/unordered-containers-0.2.10.0/docs/src/Data.HashMap.Base.html#lookup

**Cabal?**
I'm not familiar with Cabal so didn't test it / not sure if it generates the same structure of directories
