### PR TITLE
Update supported ghc versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,11 @@ These are the versions of GHC that there are binaries of `haskell-language-serve
 
 | GHC    | Linux | macOS | Windows |
 | ------ | ----- | ----- | ------- |
+| 8.10.3 | ✓     | ✓     | ✓       |
 | 8.10.2 | ✓     | ✓     | ✓       |
 | 8.10.1 | ✓     | ✓     | ✓       |
 | 8.8.4  | ✓     | ✓     | ✓       |
-| 8.8.3  | ✓     | ✓     | ✓       |
+| 8.8.3  | ✓     | ✓     |         |
 | 8.8.2  | ✓     | ✓     |         |
 | 8.6.5  | ✓     | ✓     | ✓       |
 | 8.6.4  | ✓     | ✓     | ✓       |


### PR DESCRIPTION
* They were outdated, as noted in #344 
* Soon we will have to add 8.10.4 (and remove 8.10.1)