### PR TITLE
fixed a small typo that caused the server not to be loaded in .lhs files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -106,7 +106,7 @@ async function activeServer(context: ExtensionContext, document: TextDocument) {
   if (
     (document.languageId !== 'haskell' &&
       document.languageId !== 'cabal' &&
-      document.languageId !== 'literate Haskell') ||
+      document.languageId !== 'literate haskell') ||
     (document.uri.scheme !== 'file' && document.uri.scheme !== 'untitled')
   ) {
     return;


### PR DESCRIPTION
I noticed that the extension was not always working correctly when I'm editing the .lhs files we use in class.
I then found out that it started working correctly after I open a single .hs file in my vscode session.
The problem appeared on Windows 10 in vscode aswell as on arch linux in vscodium.

