### PR TITLE
Revert serverExecutablePath from machine to resource scope

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+### 1.4.0
+
+- Restore `resource` scope for `haskell.serverExecutablePath` temporary. The `machine` scope will be set again after giving users a period of time to let them adapt theirs workflows and changing or adding some option in the extension itself to help that adjustement (see #387).
+
 ### 1.3.0
 
 - Add `haskell.releasesURL` option to override where to look for HLS releases search for HLS downloads, thanks to @soiamsoNG

--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ There are a few placeholders which will be expanded:
 - `~`, `${HOME}` and `${home}` will be expanded into your users' home folder.
 - `${workspaceFolder}` and `${workspaceRoot}` will expand into your current project root.
 
+#### Security warning
+
+The option has scope `resource` scope so it can be changed per workspace.
+This supposes it could be used to execute arbitrary programs adding a `.vscode/settings.json` in the workspace folder including this option with the appropiate path.
+For this reason its scope will be changed to `machine` so users only will be able to change it globally.
+See #387 for more details.
+
 ### Local documentation
 
 Haskell Language Server can display Haddock documentation on hover and completions if the project and

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "haskell",
   "displayName": "Haskell",
   "description": "Haskell language support powered by the Haskell Language Server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "license": "MIT",
   "publisher": "haskell",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
           "scope": "resource",
           "type": "string",
           "default": "",
-          "description": "Manually set a language server executable. Can be something on the $PATH or a path to an executable itself. Works with ~, ${HOME} and ${workspaceFolder}."
+          "markdownDescription": "Manually set a language server executable. Can be something on the $PATH or a path to an executable itself. Works with `~,` `${HOME}` and `${workspaceFolder}`. **Deprecated scope**: This option will be set to `machine` scope in a future release, so it can be changed only globally, not per workspace."
         },
         "haskell.updateBehavior": {
           "scope": "machine",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
           "description": "An optional URL to override where to check for haskell-language-server releases"
         },
         "haskell.serverExecutablePath": {
-          "scope": "machine",
+          "scope": "resource",
           "type": "string",
           "default": "",
           "description": "Manually set a language server executable. Can be something on the $PATH or a path to an executable itself. Works with ~, ${HOME} and ${workspaceFolder}."


### PR DESCRIPTION
* See #387
* It will suppose a new release (1.4.0)

//cc @marcin-rzeznicki @anka-213 @nc6