### PR TITLE
Add tracking of cabal files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -188,6 +188,7 @@ async function activateServerForFolder(context: ExtensionContext, uri: Uri, fold
     documentSelector: [
       { scheme: 'file', language: 'haskell', pattern: pat },
       { scheme: 'file', language: 'literate haskell', pattern: pat },
+      { scheme: 'file', language: 'cabal', pattern: pat },
     ],
     synchronize: {
       // Synchronize the setting section 'haskell' to the server.


### PR DESCRIPTION
Allows tracking of cabal files so the [cabal-fmt plugin](https://github.com/haskell/haskell-language-server/pull/2047) on hls can access cabal files in order to format them.