### PR TITLE
Release and publish extension using github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,13 @@ jobs:
         with:
           node-version: 12
       - run: npm ci
-      - name: Publish to Open VSX Registry
-        uses: HaaLeo/publish-vscode-extension@v0
-        with:
-          pat: ${{ secrets.OPEN_VSX_TOKEN }}
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@v0
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
+      - name: Publish to Open VSX Registry
+        continue-on-error: true
+        uses: HaaLeo/publish-vscode-extension@v0
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [created]
 
 name: Deploy Extension
 jobs:
@@ -14,12 +13,23 @@ jobs:
           node-version: 12
       - run: npm ci
       - name: Publish to Visual Studio Marketplace
+        id: publishToVSMarketplace
         uses: HaaLeo/publish-vscode-extension@v0
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
       - name: Publish to Open VSX Registry
+        id: publishToOpenVSX
         continue-on-error: true
         uses: HaaLeo/publish-vscode-extension@v0
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
+      - name: Upload extension vsix
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ steps.publishToVSMarketplace.outputs.vsixPath }}
+          asset_name: haskell-${{ github.event.release.tag_name }}.vsix
+          asset_content_type: application/vsix

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+on:
+  push:
+    tags:
+      - '*'
+
+name: Deploy Extension
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm ci
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v0
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+      - name: Publish to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v0
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          registryUrl: https://marketplace.visualstudio.com


### PR DESCRIPTION
* with the aim of replace travis-ci.org (see https://github.com/haskell/vscode-haskell/issues/385#issuecomment-888024893 for the motivation)
* using https://github.com/marketplace/actions/publish-vs-code-extension
* it publishes on releases created and upload the vsix published to the release asset
* @jaspervdj gently has created the needed secrets in the repo to make the gha work