### PR TITLE
Fix `getProjectGhcVersion` error handling

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,13 @@
 
 - Add tracking of cabal files to work together with the incoming cabal formatter plugin
 
+### 1.5.1
+
+- Add much more logging in the client side, configured with `haskell.trace.client`
+- Fix error handling of `working out project ghc` (See #421)
+  - And dont use a shell to spawn the subprocess in non windows systems
+- Add commands `Start Haskell LSP server` and `Stop Haskell LSP server`
+
 ### 1.5.0
 
 - Emit warning about limited support for ghc-9.x on hls executable download

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 - Add much more logging in the client side, configured with `haskell.trace.client`
 - Fix error handling of `working out project ghc` (See #421)
   - And dont use a shell to spawn the subprocess in non windows systems
+  - Show the progress as a cancellable notification
 - Add commands `Start Haskell LSP server` and `Stop Haskell LSP server`
 
 ### 1.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "haskell",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "haskell",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3235,8 +3235,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -5069,7 +5068,6 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
-          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -5088,7 +5086,6 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -5121,7 +5118,6 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -5134,7 +5130,6 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -5186,7 +5181,6 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -5196,7 +5190,6 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -5208,7 +5201,6 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -5257,8 +5249,7 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "string_decoder": {
           "version": "1.1.1",
@@ -5275,7 +5266,6 @@
           "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "haskell",
   "displayName": "Haskell",
   "description": "Haskell language support powered by the Haskell Language Server",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "publisher": "haskell",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -103,6 +103,17 @@
           "default": "off",
           "description": "Traces the communication between VS Code and the language server."
         },
+        "haskell.trace.client": {
+          "scope": "resource",
+          "type": "string",
+          "enum": [
+            "off",
+            "error",
+            "debug"
+          ],
+          "default": "error",
+          "description": "Traces the communication between VS Code and the language server."
+        },
         "haskell.logFile": {
           "scope": "resource",
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -323,6 +323,16 @@
         "command": "haskell.commands.restartServer",
         "title": "Haskell: Restart Haskell LSP server",
         "description": "Restart the Haskell LSP server"
+      },
+      {
+        "command": "haskell.commands.startServer",
+        "title": "Haskell: Start Haskell LSP server",
+        "description": "Start the Haskell LSP server"
+      },
+      {
+        "command": "haskell.commands.stopServer",
+        "title": "Haskell: Stop Haskell LSP server",
+        "description": "Stop the Haskell LSP server"
       }
     ]
   },

--- a/src/commands/constants.ts
+++ b/src/commands/constants.ts
@@ -1,4 +1,6 @@
 export namespace CommandNames {
   export const ImportIdentifierCommandName = 'haskell.commands.importIdentifier';
   export const RestartServerCommandName = 'haskell.commands.restartServer';
+  export const StartServerCommandName = 'haskell.commands.startServer';
+  export const StopServerCommandName = 'haskell.commands.stopServer';
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,9 +47,8 @@ export async function activate(context: ExtensionContext) {
       const client = clients.get(folder.uri.toString());
       if (client) {
         const uri = folder.uri.toString();
-        client.info('Deleting folder for clients: ${uri}');
+        client.info(`Deleting folder for clients: ${uri}`);
         clients.delete(uri);
-        client.info;
         client.info('Stopping the client');
         client.stop();
       }
@@ -103,15 +102,15 @@ function findManualExecutable(logger: Logger, uri: Uri, folder?: WorkspaceFolder
   if (exePath === '') {
     return null;
   }
-  logger.info('Trying to find the server executable in: ${exePath}');
+  logger.info(`Trying to find the server executable in: ${exePath}`);
   // Substitute path variables with their corresponding locations.
   exePath = exePath.replace('${HOME}', os.homedir).replace('${home}', os.homedir).replace(/^~/, os.homedir);
   if (folder) {
     exePath = exePath.replace('${workspaceFolder}', folder.uri.path).replace('${workspaceRoot}', folder.uri.path);
   }
-  logger.info('Location after path variables subsitution: ${exePath}');
+  logger.info(`Location after path variables subsitution: ${exePath}`);
   if (!executableExists(exePath)) {
-    throw new Error(`serverExecutablePath is set to ${exePath} but it doesn't exist and is not on the PATH`);
+    throw new Error(`serverExecutablePath is set to ${exePath} but it doesn't exist and it is not on the PATH`);
   }
   return exePath;
 }
@@ -119,10 +118,10 @@ function findManualExecutable(logger: Logger, uri: Uri, folder?: WorkspaceFolder
 /** Searches the PATH for whatever is set in serverVariant */
 function findLocalServer(context: ExtensionContext, logger: Logger, uri: Uri, folder?: WorkspaceFolder): string | null {
   const exes: string[] = ['haskell-language-server-wrapper', 'haskell-language-server'];
-  logger.info('Searching for server executables ${exes} in PATH');
+  logger.info(`Searching for server executables ${exes.join(' ')} in PATH`);
   for (const exe of exes) {
     if (executableExists(exe)) {
-      logger.info('Found server executable in PATH: ${exe}');
+      logger.info(`Found server executable in PATH: ${exe}`);
       return exe;
     }
   }
@@ -209,8 +208,8 @@ async function activateServerForFolder(context: ExtensionContext, uri: Uri, fold
     debug: { command: serverExecutable, transport: TransportKind.stdio, args, options: exeOptions },
   };
 
-  logger.info('run command: "' + serverExecutable + ' ' + args.join(' ') + '"');
-  logger.info('debug command: "' + serverExecutable + ' ' + args.join(' ') + '"');
+  logger.info(`run command: ${serverExecutable} ${args.join(' ')}`);
+  logger.info(`debug command: ${serverExecutable} ${args.join(' ')}`);
   logger.info(`server cwd: ${exeOptions.cwd}`);
 
   const pat = folder ? `${folder.uri.fsPath}/**/*` : '**/*';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,6 +68,26 @@ export async function activate(context: ExtensionContext) {
 
   context.subscriptions.push(restartCmd);
 
+  const stopCmd = commands.registerCommand(CommandNames.StopServerCommandName, async () => {
+    for (const langClient of clients.values()) {
+      langClient?.info('Stopping the client');
+      await langClient?.stop();
+      langClient?.info('Client stopped');
+    }
+  });
+
+  context.subscriptions.push(stopCmd);
+
+  const startCmd = commands.registerCommand(CommandNames.StartServerCommandName, async () => {
+    for (const langClient of clients.values()) {
+      langClient?.info('Starting the client');
+      langClient?.start();
+      langClient?.info('Client started');
+    }
+  });
+
+  context.subscriptions.push(startCmd);
+
   context.subscriptions.push(ImportIdentifier.registerCommand());
 
   // Set up the documentation browser.

--- a/src/hlsBinaries.ts
+++ b/src/hlsBinaries.ts
@@ -115,7 +115,8 @@ async function getProjectGhcVersion(
       },
       async (progress, token) => {
         return new Promise<string>((resolve, reject) => {
-          const command: string = wrapper + ' --project-ghc-version';
+          const args = ['--project-ghc-version'];
+          const command: string = wrapper + args.join(' ');
           logger.info(`Executing '${command}' in cwd '${dir}' to get the project or file ghc version`);
           token.onCancellationRequested(() => {
             logger.warn(`User canceled the execution of '${command}'`);
@@ -124,7 +125,8 @@ async function getProjectGhcVersion(
           // We execute the command in a shell for windows, to allow use .cmd or .bat scripts
           const childProcess = child_process
             .execFile(
-              command,
+              wrapper,
+              args,
               { encoding: 'utf8', cwd: dir, shell: getGithubOS() === 'Windows' },
               (err, stdout, stderr) => {
                 if (err) {

--- a/src/hlsBinaries.ts
+++ b/src/hlsBinaries.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import * as url from 'url';
 import { promisify } from 'util';
 import { env, ExtensionContext, ProgressLocation, Uri, window, workspace, WorkspaceFolder } from 'vscode';
+import { Logger } from 'vscode-languageclient';
 import { downloadFile, executableExists, httpsGetSilently } from './utils';
 import * as validate from './validation';
 
@@ -97,33 +98,59 @@ class NoBinariesError extends Error {
  * if needed. Returns null if there was an error in either downloading the wrapper or
  * in working out the ghc version
  */
-async function getProjectGhcVersion(context: ExtensionContext, dir: string, release: IRelease): Promise<string> {
+async function getProjectGhcVersion(
+  context: ExtensionContext,
+  logger: Logger,
+  dir: string,
+  release: IRelease
+): Promise<string> {
+  const title: string = 'Working out the project GHC version. This might take a while...';
+  logger.info(title);
   const callWrapper = (wrapper: string) => {
     return window.withProgress(
       {
-        location: ProgressLocation.Window,
-        title: 'Working out the project GHC version. This might take a while...',
+        location: ProgressLocation.Notification,
+        title: title,
+        cancellable: true,
       },
-      async () => {
+      async (progress, token) => {
         return new Promise<string>((resolve, reject) => {
+          const command: string = wrapper + ' --project-ghc-version';
+          logger.info('Executing `${command}` in cwd ${dir} to get the project ghc version');
+          token.onCancellationRequested(() => {
+            logger.warn('User canceled the executon of `${command}`');
+          });
           // Need to set the encoding to 'utf8' in order to get back a string
-          child_process.exec(
-            wrapper + ' --project-ghc-version',
-            { encoding: 'utf8', cwd: dir },
-            (err, stdout, stderr) => {
-              if (err) {
-                const regex = /Cradle requires (.+) but couldn't find it/;
-                const res = regex.exec(stderr);
-                if (res) {
-                  throw new MissingToolError(res[1]);
+          // We execute the command in a shell for windows, to allow use cmd or bat scripts
+          let childProcess = child_process
+            .execFile(
+              command,
+              { encoding: 'utf8', cwd: dir, shell: getGithubOS() == 'Windows' },
+              (err, stdout, stderr) => {
+                if (err) {
+                  logger.error('Error executing `${command}` with error code ${err.code}');
+                  logger.error('stderr: ${stderr}');
+                  logger.error('stdout: ${stdout}');
+                  const regex = /Cradle requires (.+) but couldn't find it/;
+                  const res = regex.exec(stderr);
+                  if (res) {
+                    throw new MissingToolError(res[1]);
+                  }
+                  throw Error(
+                    `${wrapper} --project-ghc-version exited with exit code ${err.code}:\n${stdout}\n${stderr}`
+                  );
                 }
-                throw Error(
-                  `${wrapper} --project-ghc-version exited with exit code ${err.code}:\n${stdout}\n${stderr}`
-                );
+                resolve(stdout.trim());
               }
-              resolve(stdout.trim());
-            }
-          );
+            )
+            .on('close', (code, signal) => {
+              logger.info('Execution of `${command}` closed with code ${err.code} and signal ${signal}');
+            })
+            .on('error', (err) => {
+              logger.error('Error execution `${command}`: name = ${err.name}, message = ${err.message}');
+              throw err;
+            });
+          token.onCancellationRequested((_) => childProcess.kill());
         });
       }
     );
@@ -250,10 +277,12 @@ async function getLatestReleaseMetadata(context: ExtensionContext): Promise<IRel
  */
 export async function downloadHaskellLanguageServer(
   context: ExtensionContext,
+  logger: Logger,
   resource: Uri,
   folder?: WorkspaceFolder
 ): Promise<string | null> {
   // Make sure to create this before getProjectGhcVersion
+  logger.info('Downloading haskell-language-server');
   if (!fs.existsSync(context.globalStoragePath)) {
     fs.mkdirSync(context.globalStoragePath);
   }
@@ -265,7 +294,7 @@ export async function downloadHaskellLanguageServer(
     return null;
   }
 
-  // Fetch the latest release from GitHub or from cache
+  logger.info('Fetching the latest release from GitHub or from cache');
   const release = await getLatestReleaseMetadata(context);
   if (!release) {
     let message = "Couldn't find any pre-built haskell-language-server binaries";
@@ -276,12 +305,12 @@ export async function downloadHaskellLanguageServer(
     window.showErrorMessage(message);
     return null;
   }
-
-  // Figure out the ghc version to use or advertise an installation link for missing components
+  logger.info('The latest release is ${release.tag_name}');
+  logger.info('Figure out the ghc version to use or advertise an installation link for missing components');
   const dir: string = folder?.uri?.fsPath ?? path.dirname(resource.fsPath);
   let ghcVersion: string;
   try {
-    ghcVersion = await getProjectGhcVersion(context, dir, release);
+    ghcVersion = await getProjectGhcVersion(context, logger, dir, release);
   } catch (error) {
     if (error instanceof MissingToolError) {
       const link = error.installLink();
@@ -304,8 +333,10 @@ export async function downloadHaskellLanguageServer(
   // When searching for binaries, use startsWith because the compression may differ
   // between .zip and .gz
   const assetName = `haskell-language-server-${githubOS}-${ghcVersion}${exeExt}`;
+  logger.info('Search for binary ${assetName} in release assests');
   const asset = release?.assets.find((x) => x.name.startsWith(assetName));
   if (!asset) {
+    logger.error('No binary ${assetName} found in the release assets: ' + release?.assets.map((value) => value.name));
     window.showInformationMessage(new NoBinariesError(release.tag_name, ghcVersion).message);
     return null;
   }
@@ -314,12 +345,14 @@ export async function downloadHaskellLanguageServer(
   const binaryDest = path.join(context.globalStoragePath, serverName);
 
   const title = `Downloading haskell-language-server ${release.tag_name} for GHC ${ghcVersion}`;
+  logger.info(title);
   await downloadFile(title, asset.browser_download_url, binaryDest);
   if (ghcVersion.startsWith('9.')) {
-    window.showWarningMessage(
+    let warning =
       'Currently, HLS supports GHC 9 only partially. ' +
-        'See [issue #297](https://github.com/haskell/haskell-language-server/issues/297) for more detail.'
-    );
+      'See [issue #297](https://github.com/haskell/haskell-language-server/issues/297) for more detail.';
+    logger.warn(warning);
+    window.showWarningMessage(warning);
   }
   return binaryDest;
 }

--- a/src/hlsBinaries.ts
+++ b/src/hlsBinaries.ts
@@ -110,27 +110,27 @@ async function getProjectGhcVersion(
     return window.withProgress(
       {
         location: ProgressLocation.Notification,
-        title: title,
+        title: `${title}`,
         cancellable: true,
       },
       async (progress, token) => {
         return new Promise<string>((resolve, reject) => {
           const command: string = wrapper + ' --project-ghc-version';
-          logger.info('Executing `${command}` in cwd ${dir} to get the project ghc version');
+          logger.info(`Executing '${command}' in cwd ${dir} to get the project ghc version`);
           token.onCancellationRequested(() => {
-            logger.warn('User canceled the executon of `${command}`');
+            logger.warn(`User canceled the executon of '${command}'`);
           });
           // Need to set the encoding to 'utf8' in order to get back a string
           // We execute the command in a shell for windows, to allow use cmd or bat scripts
-          let childProcess = child_process
+          const childProcess = child_process
             .execFile(
               command,
-              { encoding: 'utf8', cwd: dir, shell: getGithubOS() == 'Windows' },
+              { encoding: 'utf8', cwd: dir, shell: getGithubOS() === 'Windows' },
               (err, stdout, stderr) => {
                 if (err) {
-                  logger.error('Error executing `${command}` with error code ${err.code}');
-                  logger.error('stderr: ${stderr}');
-                  logger.error('stdout: ${stdout}');
+                  logger.error(`Error executing '${command}' with error code ${err.code}`);
+                  logger.error(`stderr: ${stderr}`);
+                  logger.error(`stdout: ${stdout}`);
                   const regex = /Cradle requires (.+) but couldn't find it/;
                   const res = regex.exec(stderr);
                   if (res) {
@@ -144,10 +144,10 @@ async function getProjectGhcVersion(
               }
             )
             .on('close', (code, signal) => {
-              logger.info('Execution of `${command}` closed with code ${err.code} and signal ${signal}');
+              logger.info(`Execution of '${command}' closed with code ${code} and signal ${signal}`);
             })
             .on('error', (err) => {
-              logger.error('Error execution `${command}`: name = ${err.name}, message = ${err.message}');
+              logger.error(`Error executing '${command}': name = ${err.name}, message = ${err.message}`);
               throw err;
             });
           token.onCancellationRequested((_) => childProcess.kill());
@@ -305,8 +305,8 @@ export async function downloadHaskellLanguageServer(
     window.showErrorMessage(message);
     return null;
   }
-  logger.info('The latest release is ${release.tag_name}');
-  logger.info('Figure out the ghc version to use or advertise an installation link for missing components');
+  logger.info(`The latest release is ${release.tag_name}`);
+  logger.info(`Figure out the ghc version to use or advertise an installation link for missing components`);
   const dir: string = folder?.uri?.fsPath ?? path.dirname(resource.fsPath);
   let ghcVersion: string;
   try {
@@ -333,10 +333,12 @@ export async function downloadHaskellLanguageServer(
   // When searching for binaries, use startsWith because the compression may differ
   // between .zip and .gz
   const assetName = `haskell-language-server-${githubOS}-${ghcVersion}${exeExt}`;
-  logger.info('Search for binary ${assetName} in release assests');
+  logger.info(`Search for binary ${assetName} in release assests`);
   const asset = release?.assets.find((x) => x.name.startsWith(assetName));
   if (!asset) {
-    logger.error('No binary ${assetName} found in the release assets: ' + release?.assets.map((value) => value.name));
+    logger.error(
+      `No binary ${assetName} found in the release assets: ${release?.assets.map((value) => value.name).join(',')}`
+    );
     window.showInformationMessage(new NoBinariesError(release.tag_name, ghcVersion).message);
     return null;
   }
@@ -348,7 +350,7 @@ export async function downloadHaskellLanguageServer(
   logger.info(title);
   await downloadFile(title, asset.browser_download_url, binaryDest);
   if (ghcVersion.startsWith('9.')) {
-    let warning =
+    const warning =
       'Currently, HLS supports GHC 9 only partially. ' +
       'See [issue #297](https://github.com/haskell/haskell-language-server/issues/297) for more detail.';
     logger.warn(warning);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,7 +46,7 @@ export class ExtensionLogger implements Logger {
 
   private logLevel(level: LogLevel, msg: string) {
     if (level <= this.level) {
-      this.log(`[${this.name}][${level}] ${msg}`);
+      this.log(`[${this.name}][${LogLevel[level].toUpperCase()}] ${msg}`);
     }
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,23 +28,26 @@ export class ExtensionLogger implements Logger {
     this.level = this.getLogLevel(level);
     this.channel = channel;
   }
-  warn(message: string): void {
+  public warn(message: string): void {
     this.logLevel(LogLevel.Warn, message);
   }
-  info(message: string): void {
+
+  public info(message: string): void {
     this.logLevel(LogLevel.Info, message);
   }
 
-  error(message: string) {
+  public error(message: string) {
     this.logLevel(LogLevel.Error, message);
   }
 
-  log(msg: string) {
+  public log(msg: string) {
     this.channel.appendLine(msg);
   }
 
   private logLevel(level: LogLevel, msg: string) {
-    if (level <= this.level) this.log('[${name}][${level}] ${msg}');
+    if (level <= this.level) {
+      this.log(`[${this.name}][${level}] ${msg}`);
+    }
   }
 
   private getLogLevel(level: string) {


### PR DESCRIPTION
- Add much more logging in the client side, configured with `haskell.trace.client`
- Fix error handling of `working out project ghc` (See #421)
  - And dont use a shell to spawn the subprocess in non windows systems
- Add commands `Start Haskell LSP server` and `Stop Haskell LSP server`
- Hopefully fixes #421