### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This extension adds language support for [Haskell](https://haskell.org), powered
 - For standalone `.hs`/`.lhs` files, [ghc](https://www.haskell.org/ghc/) must be installed and on the PATH. The easiest way to install it is with [ghcup](https://www.haskell.org/ghcup/) or [Chocolatey](https://www.haskell.org/platform/windows.html) on Windows.
 - For Cabal based projects, both ghc and [cabal-install](https://www.haskell.org/cabal/) must be installed and on the PATH. It can also be installed with [ghcup](https://www.haskell.org/ghcup/) or [Chocolatey](https://www.haskell.org/platform/windows.html) on Windows.
 - For Stack based projects, [stack](http://haskellstack.org) must be installed and on the PATH.
+- If you are installing from a offline VSIX file, you need install [language-haskell](https://github.com/JustusAdam/language-haskell) too after installation (either from the marketplace or offline).
 
 ## Configuration options
 


### PR DESCRIPTION
When installing offline from VSIX file, the extension fails as we need https://github.com/JustusAdam/language-haskell too.
This is not clear yet from the current readme.