### PR TITLE
Fix wrapper call to get project ghc version in windows and spaces in path 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "haskell",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3604,9 +3604,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-type": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "haskell",
   "displayName": "Haskell",
   "description": "Haskell language support powered by the Haskell Language Server",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "license": "MIT",
   "publisher": "haskell",
   "engines": {

--- a/src/hlsBinaries.ts
+++ b/src/hlsBinaries.ts
@@ -125,7 +125,7 @@ async function getProjectGhcVersion(
           // We execute the command in a shell for windows, to allow use .cmd or .bat scripts
           const childProcess = child_process
             .execFile(
-              wrapper,
+              getGithubOS() === 'Windows' ? `"${wrapper}"` : wrapper,
               args,
               { encoding: 'utf8', cwd: dir, shell: getGithubOS() === 'Windows' },
               (err, stdout, stderr) => {


### PR DESCRIPTION
- Fixes #435 
- I've tested that
  - Setting `shell: false` did not fix the error (so i think the original code using `spawn` would not work either)
  - Quoting the command including the path fixes it

@MuratOzsoyler hi, it would be great if you could try the beta version with this fix to see it works for you too. You have some notes on how to install manually the extension using a vsix filed (attached) here: https://github.com/haskell/vscode-haskell/issues/421#issuecomment-892602781
thanks!