### PR TITLE
Fix showDocumentation command.

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,12 @@
           "default": true,
           "description": "When opening 'Documentation' for external libraries, open in hackage by default. Set to false to instead open in vscode."
         },
+        "haskell.openSourceInHackage": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": true,
+          "description": "When opening 'Source' for external libraries, open in hackage by default. Set to false to instead open in vscode."
+        },
         "haskell.trace.server": {
           "scope": "resource",
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -96,8 +96,8 @@
         "haskell.openDocumentationInHackage": {
           "scope": "resource",
           "type": "boolean",
-          "default": false,
-          "description": "When opening 'Documentation' for external libraries, open in vscode by default. Set to true to instead open in hackage."
+          "default": true,
+          "description": "When opening 'Documentation' for external libraries, open in hackage by default. Set to false to instead open in vscode."
         },
         "haskell.trace.server": {
           "scope": "resource",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,12 @@
           "default": "ormolu",
           "description": "The formatter to use when formatting a document or range. Ensure the plugin is enabled."
         },
+        "haskell.openDocumentationInHackage": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "description": "When opening 'Documentation' for external libraries, open in vscode by default. Set to true to instead open in hackage."
+        },
         "haskell.trace.server": {
           "scope": "resource",
           "type": "string",

--- a/src/docsBrowser.ts
+++ b/src/docsBrowser.ts
@@ -72,12 +72,8 @@ export namespace DocsBrowser {
   }
 
   // registers the browser in VSCode infrastructure
-  export function registerDocsBrowser(alwaysOpenInHackage: boolean): Disposable {
-    if (alwaysOpenInHackage) {
-      return commands.registerCommand('haskell.showDocumentation', openDocumentationOnHackage);
-    } else {
-      return commands.registerCommand('haskell.showDocumentation', showDocumentation);
-    }
+  export function registerDocsBrowser(): Disposable {
+    return commands.registerCommand('haskell.showDocumentation', showDocumentation);
   }
 
   async function openDocumentationOnHackage({
@@ -143,6 +139,8 @@ export namespace DocsBrowser {
   }
 
   function processLink(ms: MarkdownString | MarkedString): string | MarkdownString {
+    const openDocsInHackage = workspace.getConfiguration('haskell').get('openDocumentationInHackage');
+    const openSourceInHackage = workspace.getConfiguration('haskell').get('openSourceInHackage');
     function transform(s: string): string {
       return s.replace(
         /\[(.+)\]\((file:.+\/doc\/(?:.*html\/libraries\/)?([^\/]+)\/(?:.*\/)?(.+\.html#?.*))\)/gi,
@@ -151,7 +149,12 @@ export namespace DocsBrowser {
           if (title == 'Documentation') {
             hackageUri = `https://hackage.haskell.org/package/${packageName}/docs/${fileAndAnchor}`;
             const encoded = encodeURIComponent(JSON.stringify({ title, localPath, hackageUri }));
-            const cmd = 'command:haskell.showDocumentation?' + encoded;
+            let cmd: string;
+            if (openDocsInHackage) {
+              cmd = 'command:haskell.openDocumentationOnHackage?' + encoded;
+            } else {
+              cmd = 'command:haskell.showDocumentation?' + encoded;
+            }
             return `[${title}](${cmd})`;
           } else if (title == 'Source') {
             hackageUri = `https://hackage.haskell.org/package/${packageName}/docs/src/${fileAndAnchor.replace(
@@ -159,7 +162,12 @@ export namespace DocsBrowser {
               '.'
             )}`;
             const encoded = encodeURIComponent(JSON.stringify({ title, localPath, hackageUri }));
-            const cmd = 'command:haskell.showDocumentation?' + encoded;
+            let cmd: string;
+            if (openSourceInHackage) {
+              cmd = 'command:haskell.openDocumentationOnHackage?' + encoded;
+            } else {
+              cmd = 'command:haskell.showDocumentation?' + encoded;
+            }
             return `[${title}](${cmd})`;
           } else {
             return s;

--- a/src/docsBrowser.ts
+++ b/src/docsBrowser.ts
@@ -147,10 +147,16 @@ export namespace DocsBrowser {
       return s.replace(
         /\[(.+)\]\((file:.+\/doc\/(?:.*html\/libraries\/)?([^\/]+)\/(src\/)?(.+\.html#?.*))\)/gi,
         (all, title, localPath, packageName, maybeSrcDir, fileAndAnchor) => {
+          let hackageUri: string;
           if (!maybeSrcDir) {
-            maybeSrcDir = '';
+            hackageUri = `https://hackage.haskell.org/package/${packageName}/docs/${fileAndAnchor}`;
+          } else {
+            hackageUri = `https://hackage.haskell.org/package/${packageName}/docs/${maybeSrcDir}${fileAndAnchor.replace(
+              /-/gi,
+              '.'
+            )}`;
           }
-          const hackageUri = `https://hackage.haskell.org/package/${packageName}/docs/${maybeSrcDir}${fileAndAnchor}`;
+
           const encoded = encodeURIComponent(JSON.stringify({ title, localPath, hackageUri }));
           const cmd = 'command:haskell.showDocumentation?' + encoded;
           return `[${title}](${cmd})`;

--- a/src/docsBrowser.ts
+++ b/src/docsBrowser.ts
@@ -145,21 +145,25 @@ export namespace DocsBrowser {
   function processLink(ms: MarkdownString | MarkedString): string | MarkdownString {
     function transform(s: string): string {
       return s.replace(
-        /\[(.+)\]\((file:.+\/doc\/(?:.*html\/libraries\/)?([^\/]+)\/(src\/)?(.+\.html#?.*))\)/gi,
-        (all, title, localPath, packageName, maybeSrcDir, fileAndAnchor) => {
+        /\[(.+)\]\((file:.+\/doc\/(?:.*html\/libraries\/)?([^\/]+)\/(?:.*\/)?(.+\.html#?.*))\)/gi,
+        (all, title, localPath, packageName, fileAndAnchor) => {
           let hackageUri: string;
-          if (!maybeSrcDir) {
+          if (title == 'Documentation') {
             hackageUri = `https://hackage.haskell.org/package/${packageName}/docs/${fileAndAnchor}`;
-          } else {
-            hackageUri = `https://hackage.haskell.org/package/${packageName}/docs/${maybeSrcDir}${fileAndAnchor.replace(
+            const encoded = encodeURIComponent(JSON.stringify({ title, localPath, hackageUri }));
+            const cmd = 'command:haskell.showDocumentation?' + encoded;
+            return `[${title}](${cmd})`;
+          } else if (title == 'Source') {
+            hackageUri = `https://hackage.haskell.org/package/${packageName}/docs/src/${fileAndAnchor.replace(
               /-/gi,
               '.'
             )}`;
+            const encoded = encodeURIComponent(JSON.stringify({ title, localPath, hackageUri }));
+            const cmd = 'command:haskell.showDocumentation?' + encoded;
+            return `[${title}](${cmd})`;
+          } else {
+            return s;
           }
-
-          const encoded = encodeURIComponent(JSON.stringify({ title, localPath, hackageUri }));
-          const cmd = 'command:haskell.showDocumentation?' + encoded;
-          return `[${title}](${cmd})`;
         }
       );
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,8 +90,7 @@ export async function activate(context: ExtensionContext) {
   context.subscriptions.push(ImportIdentifier.registerCommand());
 
   // Set up the documentation browser.
-  const openInHackage = workspace.getConfiguration('haskell').openDocumentationInHackage;
-  const docsDisposable = DocsBrowser.registerDocsBrowser(openInHackage);
+  const docsDisposable = DocsBrowser.registerDocsBrowser();
   context.subscriptions.push(docsDisposable);
 
   const openOnHackageDisposable = DocsBrowser.registerDocsOpenOnHackage();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,7 +90,8 @@ export async function activate(context: ExtensionContext) {
   context.subscriptions.push(ImportIdentifier.registerCommand());
 
   // Set up the documentation browser.
-  const docsDisposable = DocsBrowser.registerDocsBrowser();
+  const openInHackage = workspace.getConfiguration('haskell').openDocumentationInHackage;
+  const docsDisposable = DocsBrowser.registerDocsBrowser(openInHackage);
   context.subscriptions.push(docsDisposable);
 
   const openOnHackageDisposable = DocsBrowser.registerDocsOpenOnHackage();


### PR DESCRIPTION
It is not a perfect solution but I think it's a bit better than having an empty webview

### Fix showDocumentation command
I removed the iframe and instead pass the html directly to the webview.

I had to set `base` url to the documentation directory so that the css files can be fetched properly. 

The links in the opened documentation are broken and they can't be opened in the webview (at least I couldn't figure out how to do that), when you click on a link it opens it it the users browser but because we have base url set, the opened link points to something like `https://file+.vscode-resource.vscode-webview.net/nix/store/n104dcsv7gc8l7c2mc2lixp220il8lk8-ghc-8.10.4-doc/share/doc/ghc/html/libraries/base-4.14.1.0/Control-Monad.html#t:Monad`.

An alternative is to have the css files required for correct haddocks rendering in the extension itself, this can be done if the css file (`linuwial.css`) is the same for every library. This way we can set the base url to hackage docs and the external links should work fine.

### New config option

Added a new configuration option `openDocumentationInHackage` which if set to true will always open documentation in user's browser on hackage and not in the webview.

### Future work
- [x] Noticed that the `source` urls on my filesystem are different from the ones on hackage. For example, 
on my system: `file:///nix/store/n104dcsv7gc8l7c2mc2lixp220il8lk8-ghc-8.10.4-doc/share/doc/ghc/html/libraries/mtl-2.2.2/src/Control-Monad-Reader-Class.html#t:MonadReader` 
vs on hackage: `https://hackage.haskell.org/package/mtl-2.2.2/docs/src/Control.Monad.Reader.Class.html#MonadReader` (notice the `.`s vs the `-`s).
This can be fixed in the `processLink` function. (Fixed in c59ae946f96a92eb513fce31e6f7180526bf4dac)

- [x] It'll also be nice to have a separate command for `showSource` and a corresponding configuration option to either always view it in vscode vs hackage. (Added `openSourceInHackage` setting in c8f70396d3951fdf9606ed94934d67e2ee9fbda5)