### PR TITLE
Fix ci: ensure we have a supported ghc version in PATH

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,12 @@ jobs:
         uses: HaaLeo/publish-vscode-extension@v0
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
-      - name: Upload extension vsix
+      - name: Upload extension vsix to workflow artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: haskell-${{ github.event.release.tag_name }}.vsix
+          path: ${{ steps.publishToVSMarketplace.outputs.vsixPath }}
+      - name: Upload extension vsix to release assets
         uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: 10.x
       - run: npm ci
       - run: npm run webpack
-      - run: xvfb-run -a npm test
+      - run: xvfb-run -s '-screen 0 640x480x16' -a npm test
         if: runner.os == 'Linux'
       - run: npm test
         if: runner.os != 'Linux'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,20 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 10.x
+      - name: Ensure there is a supported ghc versions
+        uses: haskell/actions/setup@v1
+        with:
+          ghc-version: 9.0.1
       - run: npm ci
       - run: npm run webpack
       - run: xvfb-run -s '-screen 0 640x480x16' -a npm test
         if: runner.os == 'Linux'
       - run: npm test
         if: runner.os != 'Linux'
+      - name: Upload log file to workflow artifacts on error
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: extension-${{ matrix.os }}.log
+          path: test-workspace/hls.log
+

--- a/package.json
+++ b/package.json
@@ -109,9 +109,10 @@
           "enum": [
             "off",
             "error",
+            "info",
             "debug"
           ],
-          "default": "error",
+          "default": "info",
           "description": "Sets the log level in the client side."
         },
         "haskell.logFile": {

--- a/package.json
+++ b/package.json
@@ -398,7 +398,7 @@
     "@types/request-promise-native": "^1.0.17",
     "@types/vscode": "^1.52.0",
     "@types/yauzl": "^2.9.1",
-    "@vscode/test-electron": "^1.6.1",
+    "@vscode/test-electron": "^1.6.2",
     "glob": "^7.1.4",
     "husky": "^7.0.2",
     "mocha": "^9.1.2",

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -1,3 +1,4 @@
+// tslint:disable: no-console
 import * as cp from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -28,6 +29,7 @@ async function main() {
     const extensionTestsPath = path.resolve(__dirname, './suite/index');
 
     const testWorkspace = path.resolve(__dirname, '../../test-workspace');
+    console.log(`Test workspace: ${testWorkspace}`);
 
     if (!fs.existsSync(testWorkspace)) {
       fs.mkdirSync(testWorkspace);

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -1,5 +1,6 @@
 // tslint:disable: no-console
 import * as assert from 'assert';
+import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { TextEncoder } from 'util';
@@ -10,12 +11,12 @@ function getExtension() {
   return vscode.extensions.getExtension('haskell.haskell');
 }
 
-async function delay(ms: number) {
-  return new Promise((resolve) => setTimeout(() => resolve(false), ms));
+async function delay(seconds: number) {
+  return new Promise((resolve) => setTimeout(() => resolve(false), seconds * 1000));
 }
 
 async function withTimeout(seconds: number, f: Promise<any>) {
-  return Promise.race([f, delay(seconds * 1000)]);
+  return Promise.race([f, delay(seconds)]);
 }
 
 function getHaskellConfig() {
@@ -31,18 +32,38 @@ function getWorkspaceFile(name: string) {
   return wsroot.with({ path: path.posix.join(wsroot.path, name) });
 }
 
-async function deleteWorkspaceFiles() {
-  const dirContents = await vscode.workspace.fs.readDirectory(getWorkspaceRoot().uri);
-  console.log(`Deleting test ws contents: ${dirContents}`);
+async function deleteWorkspaceFiles(pred?: (fileType: [string, vscode.FileType]) => boolean) {
+  await deleteFiles(getWorkspaceRoot().uri, pred);
+}
+
+function getExtensionLogContent(): string | undefined {
+  const extLog = getWorkspaceFile('hls.log').fsPath;
+  if (fs.existsSync(extLog)) {
+    const logContents = fs.readFileSync(extLog);
+    return logContents.toString();
+  } else {
+    console.log(`${extLog} does not exist!`);
+    return undefined;
+  }
+}
+
+async function deleteFiles(dir: vscode.Uri, pred?: (fileType: [string, vscode.FileType]) => boolean) {
+  const dirContents = await vscode.workspace.fs.readDirectory(dir);
+  console.log(`Deleting ${dir} contents: ${dirContents}`);
   dirContents.forEach(async ([name, type]) => {
     const uri: vscode.Uri = getWorkspaceFile(name);
-    console.log(`Deleting ${uri}`);
-    await vscode.workspace.fs.delete(getWorkspaceFile(name), { recursive: true });
+    if (!pred || pred([name, type])) {
+      console.log(`Deleting ${uri}`);
+      await vscode.workspace.fs.delete(getWorkspaceFile(name), {
+        recursive: true, useTrash: false
+      });
+    }
   });
 }
 
 suite('Extension Test Suite', () => {
   const disposables: vscode.Disposable[] = [];
+  const filesCreated: Map<string, Promise<vscode.Uri>> = new Map();
 
   async function existsWorkspaceFile(pattern: string, pred?: (uri: vscode.Uri) => boolean) {
     const relPath: vscode.RelativePattern = new vscode.RelativePattern(getWorkspaceRoot(), pattern);
@@ -65,9 +86,17 @@ suite('Extension Test Suite', () => {
     await getHaskellConfig().update('logFile', 'hls.log');
     await getHaskellConfig().update('trace.server', 'messages');
     await getHaskellConfig().update('releasesDownloadStoragePath', path.normalize(getWorkspaceFile('bin').fsPath));
-    await getHaskellConfig().update('serverEnvironment', { XDG_CACHE_HOME: path.normalize(getWorkspaceFile('cache-test').fsPath) });
+    await getHaskellConfig().update('serverEnvironment',
+      { XDG_CACHE_HOME: path.normalize(getWorkspaceFile('cache-test').fsPath) });
     const contents = new TextEncoder().encode('main = putStrLn "hi vscode tests"');
     await vscode.workspace.fs.writeFile(getWorkspaceFile('Main.hs'), contents);
+
+    const pred = (uri: vscode.Uri) => !['download', 'gz', 'zip'].includes(path.extname(uri.fsPath));
+    const exeExt = os.platform.toString() === 'win32' ? '.exe' : '';
+    filesCreated.set('wrapper', existsWorkspaceFile(`bin/haskell-language-server-wrapper*${exeExt}`, pred));
+    filesCreated.set('server', existsWorkspaceFile(`bin/haskell-language-server-[1-9]*${exeExt}`, pred));
+    filesCreated.set('log', existsWorkspaceFile('hls.log'));
+    filesCreated.set('cache', existsWorkspaceFile('cache-test'));
   });
 
   test('Extension should be present', () => {
@@ -79,40 +108,54 @@ suite('Extension Test Suite', () => {
     assert.ok(true);
   });
 
+  test('Extension should create the extension log file', async () => {
+    await vscode.workspace.openTextDocument(getWorkspaceFile('Main.hs'));
+    assert.ok(await withTimeout(30, filesCreated.get('log')!), 'Extension log not created in 30 seconds');
+  });
+
   test('HLS executables should be downloaded', async () => {
     await vscode.workspace.openTextDocument(getWorkspaceFile('Main.hs'));
-    const exeExt = os.platform.toString() === 'win32' ? '.exe' : '';
     console.log('Testing wrapper');
-    const pred = (uri: vscode.Uri) => !['download', 'gz', 'zip'].includes(path.extname(uri.fsPath));
     assert.ok(
-      await withTimeout(30, existsWorkspaceFile(`bin/haskell-language-server-wrapper*${exeExt}`, pred)),
+      await withTimeout(30, filesCreated.get('wrapper')!),
       'The wrapper executable was not downloaded in 30 seconds'
     );
     console.log('Testing server');
     assert.ok(
-      await withTimeout(60, existsWorkspaceFile(`bin/haskell-language-server-[1-9]*${exeExt}`, pred)),
+      await withTimeout(60, filesCreated.get('server')!),
       'The server executable was not downloaded in 60 seconds'
     );
   });
 
-  test('Server log should be created', async () => {
+  test('Extension log should have server output', async () => {
     await vscode.workspace.openTextDocument(getWorkspaceFile('Main.hs'));
-    assert.ok(await withTimeout(30, existsWorkspaceFile('hls.log')), 'Server log not created in 30 seconds');
+    await delay(10);
+    const logContents = getExtensionLogContent();
+    assert.ok(logContents, 'Extension log file does not exist');
+    assert.match(logContents, /INFO hls:	Registering ide configuration/,
+      'Extension log file has no hls output');
   });
 
   test('Server should inherit environment variables defined in the settings', async () => {
     await vscode.workspace.openTextDocument(getWorkspaceFile('Main.hs'));
     assert.ok(
-      // Folder will have already been created by this point, so it will not trigger watcher in existsWorkspaceFile()
-      vscode.workspace.getWorkspaceFolder(getWorkspaceFile('cache-test')),
+      await withTimeout(30, filesCreated.get('cache')!),
       'Server did not inherit XDG_CACHE_DIR from environment variables set in the settings'
     );
   });
 
   suiteTeardown(async () => {
+    console.log('Disposing all resources');
     disposables.forEach((d) => d.dispose());
+    console.log('Stopping the lsp server');
     await vscode.commands.executeCommand(CommandNames.StopServerCommandName);
-    delay(5); // to give time to shutdown server
-    await deleteWorkspaceFiles();
+    await delay(5);
+    console.log('Contents of the extension log:');
+    const logContent = getExtensionLogContent();
+    if (logContent) {
+      console.log(logContent);
+    }
+    console.log('Deleting test workspace contents');
+    await deleteWorkspaceFiles(([name, type]) => !name.includes('.log'));
   });
 });

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -55,7 +55,8 @@ async function deleteFiles(dir: vscode.Uri, pred?: (fileType: [string, vscode.Fi
     if (!pred || pred([name, type])) {
       console.log(`Deleting ${uri}`);
       await vscode.workspace.fs.delete(getWorkspaceFile(name), {
-        recursive: true, useTrash: false
+        recursive: true,
+        useTrash: false,
       });
     }
   });
@@ -86,13 +87,15 @@ suite('Extension Test Suite', () => {
     await getHaskellConfig().update('logFile', 'hls.log');
     await getHaskellConfig().update('trace.server', 'messages');
     await getHaskellConfig().update('releasesDownloadStoragePath', path.normalize(getWorkspaceFile('bin').fsPath));
-    await getHaskellConfig().update('serverEnvironment',
-      { XDG_CACHE_HOME: path.normalize(getWorkspaceFile('cache-test').fsPath) });
+    await getHaskellConfig().update('serverEnvironment', {
+      XDG_CACHE_HOME: path.normalize(getWorkspaceFile('cache-test').fsPath),
+    });
     const contents = new TextEncoder().encode('main = putStrLn "hi vscode tests"');
     await vscode.workspace.fs.writeFile(getWorkspaceFile('Main.hs'), contents);
 
     const pred = (uri: vscode.Uri) => !['download', 'gz', 'zip'].includes(path.extname(uri.fsPath));
     const exeExt = os.platform.toString() === 'win32' ? '.exe' : '';
+    // Setting up watchers before actual tests start, to ensure we will got the created event
     filesCreated.set('wrapper', existsWorkspaceFile(`bin/haskell-language-server-wrapper*${exeExt}`, pred));
     filesCreated.set('server', existsWorkspaceFile(`bin/haskell-language-server-[1-9]*${exeExt}`, pred));
     filesCreated.set('log', existsWorkspaceFile('hls.log'));
@@ -132,8 +135,7 @@ suite('Extension Test Suite', () => {
     await delay(10);
     const logContents = getExtensionLogContent();
     assert.ok(logContents, 'Extension log file does not exist');
-    assert.match(logContents, /INFO hls:	Registering ide configuration/,
-      'Extension log file has no hls output');
+    assert.match(logContents, /INFO hls:\s+Registering ide configuration/, 'Extension log file has no hls output');
   });
 
   test('Server should inherit environment variables defined in the settings', async () => {


### PR DESCRIPTION
* A recent github workflows vm update set ghc to 9.2.1 in Linux, and hls does not support it
* This pr uses haskell/actions/setup to explicitly set a supported ghc version (9.0.1)
* In the way i added some improvements to help to debug the issue:
  * The client log output is written in the log file is the config option is specified
  * Client log output has a more verbose level: debug
  * Tests use the log file contents to make checks, it is included in the workflow step and uploaded as artifact if the test suite fails

/cc @jacobprudhomme, as i have modified some of the code recently added in your pr