### PR TITLE
support old hls versions compatible with the requested ghc version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         include:
           # To test a ghc version deprecated in newer hls versions
           - os: ubuntu-latest
-            ghc: 8.10.5
+            ghc: 8.10.4
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,11 @@ jobs:
     strategy:
       matrix:
         os: [macos-11, ubuntu-latest, windows-latest]
+        ghc: [9.0.1]
+        include:
+          # To test a ghc version deprecated in newer hls versions
+          - os: ubuntu-latest
+            ghc: 8.10.5
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -22,7 +27,7 @@ jobs:
       - name: Ensure there is a supported ghc versions
         uses: haskell/actions/setup@v1
         with:
-          ghc-version: 9.0.1
+          ghc-version: ${{ matrix.ghc }}
       - run: npm ci
       - run: npm run webpack
       - run: xvfb-run -s '-screen 0 640x480x16' -a npm test

--- a/src/hlsBinaries.ts
+++ b/src/hlsBinaries.ts
@@ -250,7 +250,7 @@ async function getReleaseMetadata(context: ExtensionContext, storagePath: string
 
       if (
         releaseInfoParsed !== null && releaseInfoParsed.length > 0 &&
-        (cachedInfoParsed === null || cachedInfoParsed.length == 0
+        (cachedInfoParsed === null || cachedInfoParsed.length === 0
           || releaseInfoParsed[0].tag_name !== cachedInfoParsed[0].tag_name)
       ) {
         const promptMessage =
@@ -379,11 +379,11 @@ export async function downloadHaskellLanguageServer(
     logger.warn(warning);
     window.showWarningMessage(warning);
   }
-  if (release?.tag_name != releases[0].tag_name) {
-    const warning = `haskell-language-server ${releases[0].tag_name} for GHC ${ghcVersion} is not available on ${os.type()}. Falling back to haskell-language-server ${release?.tag_name}`
-    logger.warn(warning)
+  if (release?.tag_name !== releases[0].tag_name) {
+    const warning = `haskell-language-server ${releases[0].tag_name} for GHC ${ghcVersion} is not available on ${os.type()}. Falling back to haskell-language-server ${release?.tag_name}`;
+    logger.warn(warning);
     if (downloaded) {
-      window.showInformationMessage(warning)
+      window.showInformationMessage(warning);
     }
   }
   return binaryDest;

--- a/src/hlsBinaries.ts
+++ b/src/hlsBinaries.ts
@@ -39,8 +39,6 @@ const githubReleaseApiValidator: validate.Validator<IRelease[]> = validate.array
 
 const cachedReleaseValidator: validate.Validator<IRelease[] | null> = validate.optional(githubReleaseApiValidator);
 
-const cachedReleaseValidatorOld: validate.Validator<IRelease | null> = validate.optional(releaseValidator);
-
 // On Windows the executable needs to be stored somewhere with an .exe extension
 const exeExt = process.platform === 'win32' ? '.exe' : '';
 
@@ -223,36 +221,10 @@ async function getReleaseMetadata(context: ExtensionContext, storagePath: string
 
   const offlineCache = path.join(storagePath, 'approvedReleases.cache.json');
 
-  async function readCachedReleaseData(fallBack: boolean): Promise<IRelease[] | null> {
+  async function readCachedReleaseData(): Promise<IRelease[] | null> {
     try {
       const cachedInfo = await promisify(fs.readFile)(offlineCache, { encoding: 'utf-8' });
       return validate.parseAndValidate(cachedInfo, cachedReleaseValidator);
-    } catch (err: any) {
-      // If file doesn't exist, return null unless fallBack is true. In that case try to
-      // read from the older cache file format (1.7.1 and earlier).
-      // Consider everything else it a failure
-      if (err.code === 'ENOENT') {
-        if (fallBack) {
-          return readOldCachedReleaseData();
-        } else {
-          return null;
-        }
-      }
-      throw err;
-    }
-  }
-
-  const offlineCacheOld = path.join(storagePath, 'latestApprovedRelease.cache.json');
-
-  async function readOldCachedReleaseData(): Promise<IRelease[] | null> {
-    try {
-      const cachedInfo = await promisify(fs.readFile)(offlineCacheOld, { encoding: 'utf-8' });
-      const cached = validate.parseAndValidate(cachedInfo, cachedReleaseValidatorOld);
-      if (cached) {
-        return [cached];
-      } else {
-        return null;
-      }
     } catch (err: any) {
       // If file doesn't exist, return null, otherwise consider it a failure
       if (err.code === 'ENOENT') {
@@ -261,12 +233,11 @@ async function getReleaseMetadata(context: ExtensionContext, storagePath: string
       throw err;
     }
   }
-
   // Not all users want to upgrade right away, in that case prompt
   const updateBehaviour = workspace.getConfiguration('haskell').get('updateBehavior') as UpdateBehaviour;
 
   if (updateBehaviour === 'never-check') {
-    return readCachedReleaseData(true)
+    return readCachedReleaseData();
   }
 
   try {
@@ -275,7 +246,7 @@ async function getReleaseMetadata(context: ExtensionContext, storagePath: string
       validate.parseAndValidate(releaseInfo, githubReleaseApiValidator).filter((x) => !x.prerelease) || null;
 
     if (updateBehaviour === 'prompt') {
-      const cachedInfoParsed = await readCachedReleaseData(false);
+      const cachedInfoParsed = await readCachedReleaseData();
 
       if (
         releaseInfoParsed !== null && releaseInfoParsed.length > 0 &&
@@ -290,7 +261,7 @@ async function getReleaseMetadata(context: ExtensionContext, storagePath: string
         const decision = await window.showInformationMessage(promptMessage, 'Download', 'Nevermind');
         if (decision !== 'Download') {
           // If not upgrade, bail and don't overwrite cached version information
-          return readCachedReleaseData(true);
+          return cachedInfoParsed;
         }
       }
     }
@@ -301,7 +272,7 @@ async function getReleaseMetadata(context: ExtensionContext, storagePath: string
   } catch (githubError: any) {
     // Attempt to read from the latest cached file
     try {
-      const cachedInfoParsed = await readCachedReleaseData(true);
+      const cachedInfoParsed = await readCachedReleaseData();
 
       window.showWarningMessage(
         `Couldn't get the latest haskell-language-server releases from GitHub, used local cache instead:\n${githubError.message}`

--- a/src/hlsBinaries.ts
+++ b/src/hlsBinaries.ts
@@ -365,24 +365,26 @@ export async function downloadHaskellLanguageServer(
     window.showInformationMessage(new NoBinariesError(releases[0].tag_name, ghcVersion).message);
     return null;
   }
-  if (release?.tag_name != releases[0].tag_name) {
-    const message = `haskell-language-server ${releases[0].tag_name} for GHC ${ghcVersion} is not available on ${os.type()}. Falling back to haskell-language-server ${release?.tag_name}`
-    logger.warn(message)
-    window.showInformationMessage(message)
-  }
 
   const serverName = `haskell-language-server-${release?.tag_name}-${process.platform}-${ghcVersion}${exeExt}`;
   const binaryDest = path.join(storagePath, serverName);
 
   const title = `Downloading haskell-language-server ${release?.tag_name} for GHC ${ghcVersion}`;
   logger.info(title);
-  await downloadFile(title, asset.browser_download_url, binaryDest);
+  const downloaded = await downloadFile(title, asset.browser_download_url, binaryDest);
   if (ghcVersion.startsWith('9.')) {
     const warning =
       'Currently, HLS supports GHC 9 only partially. ' +
       'See [issue #297](https://github.com/haskell/haskell-language-server/issues/297) for more detail.';
     logger.warn(warning);
     window.showWarningMessage(warning);
+  }
+  if (release?.tag_name != releases[0].tag_name) {
+    const warning = `haskell-language-server ${releases[0].tag_name} for GHC ${ghcVersion} is not available on ${os.type()}. Falling back to haskell-language-server ${release?.tag_name}`
+    logger.warn(warning)
+    if (downloaded) {
+      window.showInformationMessage(warning)
+    }
   }
   return binaryDest;
 }


### PR DESCRIPTION
Here's a simplistic PR for addressing #454. Probably too simplistic but maybe something to start with (I've never done any TypeScript before, and JavaScript last time in 1998 lol). 
This PR cannot cope with prior versions of `latestApprovedRelease.cache.json`, so make sure to start with a clean local cache (on Linux at `:~/.config/Code/User/globalStorage/haskell.haskell`. 