### PR TITLE
Fix hole_severity option: Use integer instead of string

### DIFF
--- a/package.json
+++ b/package.json
@@ -275,7 +275,7 @@
             null
           ],
           "default": null,
-          "type": "string"
+          "type": "integer"
         },
         "haskell.plugin.tactics.config.max_use_ctor_actions": {
           "title": "Max number of constructors",


### PR DESCRIPTION
Related issue: https://github.com/haskell/vscode-haskell/issues/502