### PR TITLE
fix: change deprecated Haskell Platform install link to GHCup

### DIFF
--- a/src/hlsBinaries.ts
+++ b/src/hlsBinaries.ts
@@ -70,9 +70,7 @@ class MissingToolError extends Error {
         return Uri.parse('https://docs.haskellstack.org/en/stable/install_and_upgrade/');
       case 'Cabal':
       case 'GHC':
-        return process.platform === 'win32'
-          ? Uri.parse('https://www.haskell.org/platform/index.html#windows')
-          : Uri.parse('https://www.haskell.org/ghcup/');
+        return Uri.parse('https://www.haskell.org/ghcup/');
       default:
         return null;
     }


### PR DESCRIPTION
The Haskell Platform install link for Windows is [deprecated](https://www.haskell.org/platform/index.html#windows). Windows users can use [GHCup](https://www.haskell.org/ghcup/) to install as well.