### PR TITLE
Update README.MD GHC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,17 +89,19 @@ Note that if `haskell-language-server-wrapper`/`haskell-language-server` is alre
 
 ### Supported GHC versions
 
-These are the versions of GHC that there are binaries of `haskell-language-server-1.5.1` for. Building from source may support more versions!
+These are the versions of GHC that there are binaries of `haskell-language-server-1.6.1` for. Building from source may support more versions!
 
-| GHC                                                                              | Linux | macOS | Windows |
-| -------------------------------------------------------------------------------- | ----- | ----- | ------- |
-| 9.0.1 ([limited](https://github.com/haskell/haskell-language-server/issues/297)) | ✓     | ✓     | ✓       |
-| 8.10.7                                                                           | ✓     | ✓     | ✓       |
-| 8.10.6                                                                           | ✓     | ✓     | ✓       |
-| 8.10.5                                                                           | ✓     | ✓     | ✓       |
-| 8.8.4                                                                            | ✓     | ✓     | ✓       |
-| 8.8.3                                                                            | ✓     | ✓     |         |
-| 8.6.5                                                                            | ✓     | ✓     | ✓       |
+| GHC                                                                               | Linux | macOS | Windows |
+| --------------------------------------------------------------------------------- | ----- | ----- | ------- |
+| 9.2.1 ([limited](https://github.com/haskell/haskell-language-server/issues/2179)) | ✓     | ✓     | ✓       |
+| 9.0.2 ([limited](https://github.com/haskell/haskell-language-server/issues/297))  | ✓     | ✓     | ✓       |
+| 9.0.1 ([limited](https://github.com/haskell/haskell-language-server/issues/297))  | ✓     | ✓     | ✓       |
+| 8.10.7                                                                            | ✓     | ✓     | ✓       |
+| 8.10.6                                                                            | ✓     | ✓     | ✓       |
+| 8.10.5                                                                            | ✓     | ✓     | ✓       |
+| 8.8.4                                                                             | ✓     | ✓     | ✓       |
+| 8.8.3                                                                             | ✓     | ✓     |         |
+| 8.6.5                                                                             | ✓     | ✓     | ✓       |
 
 The exact list of binaries can be checked in the last release of haskell-language-server: <https://github.com/haskell/haskell-language-server/releases/latest>
 


### PR DESCRIPTION
Just a quick update of the README, which still listed HLS 1.5.1 and no support for GHC 9.2.1.
