### PR TITLE
Add eval plugin configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -227,6 +227,18 @@
           "default": true,
           "description": "Enables eval plugin"
         },
+        "haskell.plugin.eval.config.diff": {
+          "markdownDescription": "When reloading haddock test results in changes, mark it with WAS/NOW.",
+          "scope": "resource",
+          "default": true,
+          "type": "boolean"
+        },
+        "haskell.plugin.eval.config.exception": {
+          "markdownDescription": "When the command results in an exception, mark it with `*** Exception:`.",
+          "scope": "resource",
+          "default": false,
+          "type": "boolean"
+        },
         "haskell.plugin.moduleName.globalOn": {
           "scope": "resource",
           "type": "boolean",


### PR DESCRIPTION
Eval plugin gains new configuration options in haskell/haskell-language-server#2622 (diff) and haskell/haskell-language-server#2775 (exception).