### PR TITLE
Remove stdout/sterr from user error message

### DIFF
--- a/src/hlsBinaries.ts
+++ b/src/hlsBinaries.ts
@@ -147,7 +147,9 @@ async function callAsync(
                   if (stdout) {
                     logger.error(`stdout: ${stdout}`);
                   }
-                  reject(Error(`${command} exited with exit code ${err.code}:\n${stdout}\n${stderr}`));
+                  reject(Error(`\`${command}\` exited with exit code ${err.code}.
+                              Consult the [Extensions Output](https://github.com/haskell/vscode-haskell#investigating-and-reporting-problems)
+                              for details.`));
                 } else {
                   resolve(stdout?.trim());
                 }


### PR DESCRIPTION
The user doesn't need to see the full output, if they truly need it,
they can consult the extensions output and otherwise the user may be
overloaded with output.

Turns this:
![image](https://user-images.githubusercontent.com/8463814/160115225-c166a9e4-fab1-4868-9ea4-a3baffd6b0a2.png)

Into this:
![image](https://user-images.githubusercontent.com/8463814/160115547-6a1f4843-1fc4-4be7-9270-a51422b1b8f5.png)
