### PR TITLE
Introduce 'haskell.toolchain' setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,57 @@ or set `haskell.serverExecutablePath` (overrides all other settings) to a valid 
 
 If you need to set mirrors for ghcup download info, check the settings `haskell.metadataURL` and `haskell.releasesURL`.
 
+### Setting a specific toolchain
+
+When `manageHLS` is set to `GHCup`, you can define a specific toolchain (`hls`, `ghc`, `cabal` and `stack`),
+either globally or per project. E.g.:
+
+```json
+{
+    "haskell.toolchain": {
+        "hls": "1.6.1.1",
+        "cabal": "recommended",
+        "stack": null
+    }    
+}
+```
+
+This means:
+
+1. install the `ghc` version corresponding to the project (default, because it's omitted)
+2. install `hls` 1.6.1.1
+3. install the recommended `cabal` version from ghcup
+4. don't install any `stack` version
+
+Another config could be:
+
+```json
+{
+    "haskell.toolchain": {
+        "ghc": "9.2.2",
+        "hls": "latest"
+        "cabal": "recommended"
+    }    
+}
+```
+
+Meaning:
+
+1. install `ghc` 9.2.2 regardless of what the project requires
+2. always install latest `hls`, even if it doesn't support the given GHC version
+3. install recommended `cabal`
+4. install latest `stack` (default, because it's omitted)
+
+The defaults (when omitted) are as follows:
+
+1. install the project required `ghc` (corresponding to `with-compiler` setting in `cabal.project` for example)
+2. install the latest `hls` version that supports the project required ghc version
+3. install latest `cabal`
+3. install latest `stack`
+
+When a the value is `null`, the extension will refrain from installing it.
+
+
 ### Supported GHC versions
 
 These are the versions of GHC that there are binaries of `haskell-language-server-1.6.1` for. Building from source may support more versions!

--- a/package.json
+++ b/package.json
@@ -177,23 +177,11 @@
             "Discovers HLS and other executables in system PATH"
           ]
         },
-        "haskell.installStack": {
+        "haskell.toolchain": {
           "scope": "resource",
-          "type": "boolean",
-          "default": true,
-          "description": "Whether to also install/manage stack when 'manageHLS' is set to 'GHCup'."
-        },
-        "haskell.installCabal": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": true,
-          "description": "Whether to also install/manage cabal when 'manageHLS' is set to 'GHCup'."
-        },
-        "haskell.installGHC": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": true,
-          "description": "Whether to also install/manage GHC when 'manageHLS' is set to 'GHCup'."
+          "type": "object",
+          "default": {},
+          "description": "When manageHLS is set to GHCup, this can overwrite the automatic toolchain configuration with a more specific one. When a tool is omitted, the extension will manage the version (for 'ghc' we try to figure out the version the project requires). The format is '{\"tool\": \"version\", ...}'. 'version' accepts all identifiers that 'ghcup' accepts."
         },
         "haskell.upgradeGHCup": {
           "scope": "resource",

--- a/package.json
+++ b/package.json
@@ -163,6 +163,12 @@
           "default": {},
           "markdownDescription": "Define environment variables for the language server."
         },
+        "haskell.promptBeforeDownloads": {
+          "scope": "machine",
+          "type": "boolean",
+          "default": "true",
+          "markdownDescription": "Prompt before performing any downloads."
+        },
         "haskell.manageHLS": {
           "scope": "resource",
           "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -145,11 +145,15 @@ async function activateServerForFolder(context: ExtensionContext, uri: Uri, fold
     logger.log(`  ${key}: ${value}`);
   });
 
-  let serverExecutable;
+  let serverExecutable: string;
   let addInternalServerPath: string | undefined; // if we download HLS, add that bin dir to PATH
   try {
-    serverExecutable = await findHaskellLanguageServer(context, logger, currentWorkingDir, folder);
-    addInternalServerPath = path.dirname(serverExecutable);
+    [serverExecutable, addInternalServerPath] = await findHaskellLanguageServer(
+      context,
+      logger,
+      currentWorkingDir,
+      folder
+    );
     if (!serverExecutable) {
       return;
     }

--- a/src/hlsBinaries.ts
+++ b/src/hlsBinaries.ts
@@ -324,15 +324,15 @@ export async function findHaskellLanguageServer(
     if (promptBeforeDownloads) {
       const hlsInstalled = latestHLS
         ? await toolInstalled(context, logger, 'hls', latestHLS)
-        : ([true, 'hls', ''] as [boolean, string, string]);
+        : ([true, 'hls', ''] as [boolean, Tool, string]);
       const cabalInstalled = latestCabal
         ? await toolInstalled(context, logger, 'cabal', latestCabal)
-        : ([true, 'cabal', ''] as [boolean, string, string]);
+        : ([true, 'cabal', ''] as [boolean, Tool, string]);
       const stackInstalled = latestStack
         ? await toolInstalled(context, logger, 'stack', latestStack)
-        : ([true, 'stack', ''] as [boolean, string, string]);
+        : ([true, 'stack', ''] as [boolean, Tool, string]);
       const ghcInstalled = (await executableExists('ghc'))
-        ? ([true, 'ghc', ''] as [boolean, string, string])
+        ? ([true, 'ghc', ''] as [boolean, Tool, string])
         : await toolInstalled(context, logger, 'ghc', recGHC!);
       const toInstall = [hlsInstalled, cabalInstalled, stackInstalled, ghcInstalled]
         .filter(([b, t, v]) => !b)
@@ -400,10 +400,10 @@ export async function findHaskellLanguageServer(
     if (promptBeforeDownloads) {
       const hlsInstalled = projectHls
         ? await toolInstalled(context, logger, 'hls', projectHls)
-        : ([true, 'hls', ''] as [boolean, string, string]);
+        : ([true, 'hls', ''] as [boolean, Tool, string]);
       const ghcInstalled = projectGhc
         ? await toolInstalled(context, logger, 'ghc', projectGhc)
-        : ([true, 'ghc', ''] as [boolean, string, string]);
+        : ([true, 'ghc', ''] as [boolean, Tool, string]);
       const toInstall = [hlsInstalled, ghcInstalled].filter(([b, t, v]) => !b).map(([_, t, v]) => `${t}-${v}`);
       if (toInstall.length > 0) {
         const decision = await window.showInformationMessage(
@@ -678,7 +678,7 @@ export async function getStoragePath(context: ExtensionContext): Promise<string>
 }
 
 // the tool might be installed or not
-async function getLatestToolFromGHCup(context: ExtensionContext, logger: Logger, tool: string): Promise<string> {
+async function getLatestToolFromGHCup(context: ExtensionContext, logger: Logger, tool: Tool): Promise<string> {
   // these might be custom/stray/compiled, so we try first
   const installedVersions = await callGHCup(
     context,
@@ -698,7 +698,7 @@ async function getLatestToolFromGHCup(context: ExtensionContext, logger: Logger,
 async function getLatestAvailableToolFromGHCup(
   context: ExtensionContext,
   logger: Logger,
-  tool: string,
+  tool: Tool,
   tag?: string,
   criteria?: string
 ): Promise<string> {
@@ -772,9 +772,9 @@ async function getHLSesFromGHCup(context: ExtensionContext, logger: Logger): Pro
 async function toolInstalled(
   context: ExtensionContext,
   logger: Logger,
-  tool: string,
+  tool: Tool,
   version: string
-): Promise<[boolean, string, string]> {
+): Promise<[boolean, Tool, string]> {
   const b = await callGHCup(context, logger, ['whereis', tool, version], undefined, false)
     .then((x) => true)
     .catch((x) => false);

--- a/src/hlsBinaries.ts
+++ b/src/hlsBinaries.ts
@@ -250,7 +250,12 @@ export async function findHaskellLanguageServer(
   if (manageHLS !== 'GHCup' && (!context.globalState.get('pluginInitialized') as boolean | null)) {
     const promptMessage = 'How do you want the extension to manage/discover HLS and the relevant toolchain?';
 
-    const popup = window.showInformationMessage(promptMessage, 'Automatically via GHCup', 'Manually via PATH');
+    const popup = window.showInformationMessage(
+      promptMessage,
+      { modal: true },
+      'Automatically via GHCup',
+      'Manually via PATH'
+    );
 
     const decision = (await popup) || null;
     if (decision === 'Automatically via GHCup') {
@@ -403,6 +408,7 @@ export async function findHaskellLanguageServer(
       if (toInstall.length > 0) {
         const decision = await window.showInformationMessage(
           `Need to download ${toInstall.join(', ')}, continue?`,
+          { modal: true },
           'Yes',
           'No',
           "Yes, don't ask again"

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -130,6 +130,7 @@ suite('Extension Test Suite', () => {
       , joinUri(getWorkspaceRoot().uri, 'bin', process.platform === 'win32' ? 'ghcup' : '.ghcup', 'cache')
       ]
     );
+    await getHaskellConfig().update('promptBeforeDownloads', false, vscode.ConfigurationTarget.Global);
     await getHaskellConfig().update('manageHLS', 'GHCup');
     await getHaskellConfig().update('logFile', 'hls.log');
     await getHaskellConfig().update('trace.server', 'messages');


### PR DESCRIPTION
Wrt https://github.com/haskell/vscode-haskell/issues/561

----

Example config in current workspace:

```json
{
    "haskell.toolchain": {
        "hls": "1.6.1.1",
        "cabal": "recommended",
        "stack": null
    }    
}
```

This means:

1. install the `ghc` version corresponding to the project (default, because it's omitted)
2. install hls 1.6.1.1
3. install the recommended cabal version from ghcup
4. don't install any stack version

Another config:

```json
{
    "haskell.toolchain": {
        "ghc": "9.2.2",
        "hls": "latest"
        "cabal": "recommended",
    }    
}
```

1. install ghc 9.2.2 regardless of what the project requires
2. always install latest HLS, even if it doesn't support the given GHC version
3. install recommended cabal
4. install latest stack (default, because it's omitted)