### PR TITLE
Bump required VSCode version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "publisher": "haskell",
   "engines": {
-    "vscode": "^1.52.0"
+    "vscode": "^1.63.0"
   },
   "keywords": [
     "language",


### PR DESCRIPTION
We can't perform pre-releases otherwise.