### PR TITLE
Prepare pre-release 2.1.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,45 +1,52 @@
 # Changelog for vscode-haskell
 
-## 2.0.0-alpha
+## 2.1.0 (Pre-release)
+
+- Prepare pre-release 2.1.0
+  ([#574](https://github.com/haskell/vscode-haskell/pull/574)) by @fendor
+- Enable pre-release feature for VSX Marketplace
+  ([#573](https://github.com/haskell/vscode-haskell/pull/573)) by @fendor
+
+## 2.0.0 (Pre-release)
 
 - Add prettier script
-([#566](https://github.com/haskell/vscode-haskell/pull/566)) by @fendor
+  ([#566](https://github.com/haskell/vscode-haskell/pull/566)) by @fendor
 - Remove accidental run command
-([#565](https://github.com/haskell/vscode-haskell/pull/565)) by @fendor
+  ([#565](https://github.com/haskell/vscode-haskell/pull/565)) by @fendor
 - Upgrade dependencies
-([#564](https://github.com/haskell/vscode-haskell/pull/564)) by @fendor
+  ([#564](https://github.com/haskell/vscode-haskell/pull/564)) by @fendor
 - Add new configuration options for rename plugin
-([#563](https://github.com/haskell/vscode-haskell/pull/563)) by @OliverMadine
+  ([#563](https://github.com/haskell/vscode-haskell/pull/563)) by @OliverMadine
 - Introduce 'haskell.toolchain' setting
-([#562](https://github.com/haskell/vscode-haskell/pull/562)) by @hasufell
+  ([#562](https://github.com/haskell/vscode-haskell/pull/562)) by @hasufell
 - Improve
-([#558](https://github.com/haskell/vscode-haskell/pull/558)) by @hasufell
+  ([#558](https://github.com/haskell/vscode-haskell/pull/558)) by @hasufell
 - Remove stdout/sterr from user error message
-([#556](https://github.com/haskell/vscode-haskell/pull/556)) by @fendor
+  ([#556](https://github.com/haskell/vscode-haskell/pull/556)) by @fendor
 - Fix npm security issue
-([#555](https://github.com/haskell/vscode-haskell/pull/555)) by @fendor
+  ([#555](https://github.com/haskell/vscode-haskell/pull/555)) by @fendor
 - No colour output for GHCup
-([#554](https://github.com/haskell/vscode-haskell/pull/554)) by @fendor
+  ([#554](https://github.com/haskell/vscode-haskell/pull/554)) by @fendor
 - Add eval plugin configuration
-([#549](https://github.com/haskell/vscode-haskell/pull/549)) by @xsebek
+  ([#549](https://github.com/haskell/vscode-haskell/pull/549)) by @xsebek
 - Manage all the Haskell things
-([#547](https://github.com/haskell/vscode-haskell/pull/547)) by @hasufell
+  ([#547](https://github.com/haskell/vscode-haskell/pull/547)) by @hasufell
 - Consider user installed HLSes (e.g. via ghcup compile)
-([#543](https://github.com/haskell/vscode-haskell/pull/543)) by @hasufell
+  ([#543](https://github.com/haskell/vscode-haskell/pull/543)) by @hasufell
 - Bump lodash-es from 4.17.15 to 4.17.21
-([#539](https://github.com/haskell/vscode-haskell/pull/539)) by @dependabot[bot]
+  ([#539](https://github.com/haskell/vscode-haskell/pull/539)) by @dependabot[bot]
 - Update README.MD GHC support
-([#537](https://github.com/haskell/vscode-haskell/pull/537)) by @cptwunderlich
+  ([#537](https://github.com/haskell/vscode-haskell/pull/537)) by @cptwunderlich
 - fix: change deprecated Haskell Platform install link to GHCup
-([#536](https://github.com/haskell/vscode-haskell/pull/536)) by @HEIGE-PCloud
+  ([#536](https://github.com/haskell/vscode-haskell/pull/536)) by @HEIGE-PCloud
 - Update HLS installation method
-([#533](https://github.com/haskell/vscode-haskell/pull/533)) by @hasufell
+  ([#533](https://github.com/haskell/vscode-haskell/pull/533)) by @hasufell
 - Bump ajv from 6.12.0 to 6.12.6
-([#532](https://github.com/haskell/vscode-haskell/pull/532)) by @dependabot[bot]
+  ([#532](https://github.com/haskell/vscode-haskell/pull/532)) by @dependabot[bot]
 - Fixes related with paths
-([#518](https://github.com/haskell/vscode-haskell/pull/518)) by @jneira
+  ([#518](https://github.com/haskell/vscode-haskell/pull/518)) by @jneira
 - Reorganize troubleshooting section
-([#516](https://github.com/haskell/vscode-haskell/pull/516)) by @jneira
+  ([#516](https://github.com/haskell/vscode-haskell/pull/516)) by @jneira
 
 ## 1.8.0
 

--- a/Contributing.md
+++ b/Contributing.md
@@ -45,3 +45,13 @@ A brief overview of the files,
 ## Helpful Reading Material
 
 We recommend checking out [Your First VS Code Extension](https://code.visualstudio.com/docs/extensions/example-hello-world) and [Creating a Language Server](https://code.visualstudio.com/docs/extensions/example-language-server) for some introduction to VS Code extensions.
+
+## Release Checklist
+
+- [ ] SemVer Compatible Version Bump in `package.json`
+  - For pre-releases, we follow the version convention at: https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions. We use `major.EVEN_NUMBER.patch` for release versions and `major.ODD_NUMBER.patch` for pre-release versions. For example: `2.0.*` for release and `2.1.*` for pre-release.
+- [ ] Update ChangeLog.md. The output of `./GenChangelogs.hs` usually suffices.
+- [ ] Update the README.md to have no outdated information.
+- [ ] Make sure CI is succeeding.
+- [ ] If you perform a pre-release, create a [pre-release in Github](https://github.com/haskell/vscode-haskell/releases). The github action will perform the appropriate actions automatically and publish the pre-release of the extension to VSCode- and VSX-Marketplace.
+- [ ] If you perform a release, create a [release in Github](https://github.com/haskell/vscode-haskell/releases). The github action will perform the appropriate actions automatically and publish the extension to VSCode- and VSX-Marketplace.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "haskell",
   "displayName": "Haskell",
   "description": "Haskell language support powered by the Haskell Language Server",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "publisher": "haskell",
   "engines": {


### PR DESCRIPTION
Additionally, add a release checklist for future contributors.

Most notably, this version is changed to `2.1.0` to follow the version recommendation at https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions

> ... we recommend that extensions use major.EVEN_NUMBER.patch for release versions and major.ODD_NUMBER.patch for pre-release versions. For example: 0.2.* for release and 0.3.* for pre-release.

with the reasoning:

> VS Code will auto update extensions to the highest version available, so even if a user opted into a pre-release version and there is an extension release with a higher version, that user will be updated to the released version.

So, the next  *proper* release is going to be `2.0.1`, and the next pre-release is `2.1.0`. Unless there is a strong incentive to do so, we won't yank the pre-release `2.0.0`, mainly because it feels like unnecessary work.