### PR TITLE
Add indentation for list item in markdown

### DIFF
--- a/GenChangelogs.hs
+++ b/GenChangelogs.hs
@@ -38,6 +38,6 @@ main = do
         | otherwise = False
 
   forM_ prsAfterLastTag $ \SimplePullRequest{..} ->
-    putStrLn $ T.unpack $ "- " <> simplePullRequestTitle <>
-      "\n([#" <> T.pack (show $ unIssueNumber simplePullRequestNumber) <> "](" <> getUrl simplePullRequestHtmlUrl <> "))" <>
+    putStrLn $ T.unpack $ "- " <> simplePullRequestTitle <> "\n" <>
+      "  ([#" <> T.pack (show $ unIssueNumber simplePullRequestNumber) <> "](" <> getUrl simplePullRequestHtmlUrl <> "))" <>
       " by @" <> untagName (simpleUserLogin simplePullRequestUser)


### PR DESCRIPTION
This way the list can be copy-pasted into ChangeLog.md and fits the style of the rest of the document