### PR TITLE
Add Tool class and print stacktraces

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,57 @@
+import { Uri } from 'vscode';
+
+// tslint:disable max-classes-per-file
+export class HlsError extends Error {}
+
+export class MissingToolError extends HlsError {
+  public readonly tool: string;
+  constructor(tool: string) {
+    let prettyTool: string;
+    switch (tool.toLowerCase()) {
+      case 'stack':
+        prettyTool = 'Stack';
+        break;
+      case 'cabal':
+        prettyTool = 'Cabal';
+        break;
+      case 'ghc':
+        prettyTool = 'GHC';
+        break;
+      case 'ghcup':
+        prettyTool = 'GHCup';
+        break;
+      case 'haskell-language-server':
+        prettyTool = 'HLS';
+        break;
+      case 'hls':
+        prettyTool = 'HLS';
+        break;
+      default:
+        prettyTool = tool;
+        break;
+    }
+    super(`Project requires ${prettyTool} but it isn't installed`);
+    this.tool = prettyTool;
+  }
+
+  public installLink(): Uri | null {
+    switch (this.tool) {
+      case 'Stack':
+        return Uri.parse('https://docs.haskellstack.org/en/stable/install_and_upgrade/');
+      case 'GHCup':
+      case 'Cabal':
+      case 'HLS':
+      case 'GHC':
+        return Uri.parse('https://www.haskell.org/ghcup/');
+      default:
+        return null;
+    }
+  }
+}
+
+export class NoMatchingHls extends Error {
+  constructor(readonly ghcProjVersion: string) {
+    const noMatchingHLS = `No HLS version was found for supporting GHC ${ghcProjVersion}.`;
+    super(noMatchingHLS);
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,8 @@ import {
 import { CommandNames } from './commands/constants';
 import { ImportIdentifier } from './commands/importIdentifier';
 import { DocsBrowser } from './docsBrowser';
-import { findHaskellLanguageServer, IEnvVars, MissingToolError } from './hlsBinaries';
+import { HlsError, MissingToolError } from './errors';
+import { findHaskellLanguageServer, IEnvVars } from './hlsBinaries';
 import { addPathToProcessPath, expandHomeDir, ExtensionLogger } from './utils';
 
 // The current map of documents & folders to language servers.
@@ -172,8 +173,17 @@ async function activateServerForFolder(context: ExtensionContext, uri: Uri, fold
       } else {
         await window.showErrorMessage(e.message);
       }
+    } else if (e instanceof HlsError) {
+      logger.error(`General HlsError: ${e.message}`);
+      if (e.stack) {
+        logger.error(`${e.stack}`);
+      }
+      window.showErrorMessage(e.message);
     } else if (e instanceof Error) {
-      logger.error(`Error getting the server executable: ${e.message}`);
+      logger.error(`Internal Error: ${e.message}`);
+      if (e.stack) {
+        logger.error(`${e.stack}`);
+      }
       window.showErrorMessage(e.message);
     }
     return;


### PR DESCRIPTION
Introduces HlsError hierarchy because there might be more errors in the future (Apparently, I can't shake off my java developer education)

Also, removes ad-hoc defined `[boolean, string, string]` type because no one can remember the meaning of such a construct. Replaces with class and proper name.