### PR TITLE
Fix trace.server option

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
           "type": "string",
           "enum": [
             "off",
-            "messages"
+            "messages",
+            "verbose"
           ],
           "default": "off",
           "description": "Traces the communication between VS Code and the language server."

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -282,7 +282,7 @@ async function activateServerForFolder(context: ExtensionContext, uri: Uri, fold
   };
 
   // Create the LSP client.
-  const langClient = new LanguageClient(langName, langName, serverOptions, clientOptions);
+  const langClient = new LanguageClient('haskell', langName, serverOptions, clientOptions);
 
   // Register ClientCapabilities for stuff like window/progress
   langClient.registerProposedFeatures();


### PR DESCRIPTION
The trace server option is useful for debugging the JSON messages sent between the LSP client and server. A standardized output format is provided by `vscode-languageclient/node`, compatible with this [lsp inspector tool](https://github.com/microsoft/language-server-protocol-inspector).

To get the LanguageClient to read the trace server option from the config, the `id` passed to the language client needs to match the section used in `getConfiguration`. I also add a verbose option to the config, since it is supported by the LanguageClient.