### PR TITLE
Replace x32 with ia32 for Architecture matching

### DIFF
--- a/src/hlsBinaries.ts
+++ b/src/hlsBinaries.ts
@@ -761,7 +761,7 @@ async function getHLSesfromMetadata(context: ExtensionContext, logger: Logger): 
   const arch: Arch | null = match(process.arch)
     .with('arm', (_) => 'A_ARM' as Arch)
     .with('arm64', (_) => 'A_ARM64' as Arch)
-    .with('x32', (_) => 'A_32' as Arch)
+    .with('ia32', (_) => 'A_32' as Arch)
     .with('x64', (_) => 'A_64' as Arch)
     .otherwise((_) => null);
   if (arch === null) {


### PR DESCRIPTION
Architecture type now:

```haskell
type Architecture = 'arm' | 'arm64' | 'ia32' | 'mips' | 'mipsel' | 'ppc' | 'ppc64' | 's390' | 's390x' | 'x64';
``` 

Hope that's the correct type.