### PR TITLE
Fix test-suite for new GHCUp release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,15 @@
 version: 2
 updates:
-
   # NOTE: Dependabot official configuration documentation:
   # https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#package-ecosystem
 
   # Maintain dependencies for internal GitHub Actions CI for pull requests
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
 
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,12 @@ jobs:
         run: ghcup upgrade -i -f
         shell: bash
       # Setup the environment for the tests
-      - name: Ensure there is a supported ghc versions
-        uses: haskell/actions/setup@v2
-        with:
-          ghc-version: ${{ matrix.ghc }}
+      - name: Install stack
+        run: ghcup install stack recommended
+      - name: Install cabal
+        run: ghcup install cabal recommended
+      - name: Install GHC
+        run: ghcup install ghc ${{matrix.ghc}}
       - name: 'Install `tree` for MacOs'
         run: |
           brew update

--- a/README.md
+++ b/README.md
@@ -7,28 +7,28 @@ As almost all features are provided by the server you might find interesting rea
 
 ## Table of Contents
 
-* [Setup](#setup)
-* [Features](#features)
-* [Requirements](#requirements)
-* [Configuration options](#configuration-options)
-  * [Path to server executable](#path-to-server-executable)
-	 * [Security warning](#security-warning)
-  * [Set additional environment variables for the server](#set-additional-environment-variables-for-the-server)
-  * [Downloaded binaries](#downloaded-binaries)
-  * [Setting a specific toolchain](#setting-a-specific-toolchain)
-  * [Supported GHC versions](#supported-ghc-versions)
-* [Using multi-root workspaces](#using-multi-root-workspaces)
-* [Investigating and reporting problems](#investigating-and-reporting-problems)
-* [FAQ](#faq)
-  * [Troubleshooting](#troubleshooting)
-	 * [Check issues and tips in the haskell-language-server project](#check-issues-and-tips-in-the-haskell-language-server-project)
-	 * [Restarting the language server](#restarting-the-language-server)
-	 * [Failed to get project GHC version on darwin M1 with stack](#failed-to-get-project-ghc-version-on-darwin-m1-with-stack)
-	 * [GHC ABIs don't match](#ghc-abis-dont-match)
-	 * [Using an old configuration](#using-an-old-configuration)
-	 * [Stack/Cabal/GHC can not be found](#stackcabalghc-can-not-be-found)
-* [Contributing](#contributing)
-* [Release Notes](#release-notes)
+- [Setup](#setup)
+- [Features](#features)
+- [Requirements](#requirements)
+- [Configuration options](#configuration-options)
+  - [Path to server executable](#path-to-server-executable)
+  - [Security warning](#security-warning)
+  - [Set additional environment variables for the server](#set-additional-environment-variables-for-the-server)
+  - [Downloaded binaries](#downloaded-binaries)
+  - [Setting a specific toolchain](#setting-a-specific-toolchain)
+  - [Supported GHC versions](#supported-ghc-versions)
+- [Using multi-root workspaces](#using-multi-root-workspaces)
+- [Investigating and reporting problems](#investigating-and-reporting-problems)
+- [FAQ](#faq)
+  - [Troubleshooting](#troubleshooting)
+  - [Check issues and tips in the haskell-language-server project](#check-issues-and-tips-in-the-haskell-language-server-project)
+  - [Restarting the language server](#restarting-the-language-server)
+  - [Failed to get project GHC version on darwin M1 with stack](#failed-to-get-project-ghc-version-on-darwin-m1-with-stack)
+  - [GHC ABIs don't match](#ghc-abis-dont-match)
+  - [Using an old configuration](#using-an-old-configuration)
+  - [Stack/Cabal/GHC can not be found](#stackcabalghc-can-not-be-found)
+- [Contributing](#contributing)
+- [Release Notes](#release-notes)
 
 ## Setup
 
@@ -267,7 +267,7 @@ setup-info:
   ghc:
     linux64-tinfo6:
       9.0.2:
-        url: "https://downloads.haskell.org/ghc/9.0.2/ghc-9.0.2a-x86_64-fedora27-linux.tar.xz"
+        url: 'https://downloads.haskell.org/ghc/9.0.2/ghc-9.0.2a-x86_64-fedora27-linux.tar.xz'
 ```
 
 Alternatively let GHCup install the correct bindist and then set `system-ghc: true` in your `stack.yaml`.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -179,7 +179,7 @@ async function activateServerForFolder(context: ExtensionContext, uri: Uri, fold
     } else if (e instanceof NoMatchingHls) {
       const link = e.docLink();
       logger.error(`${e.message}`);
-      if (await window.showErrorMessage(e.message, `Open documentation`)) {
+      if (await window.showErrorMessage(e.message, 'Open documentation')) {
         env.openExternal(link);
       }
     } else if (e instanceof Error) {

--- a/src/hlsBinaries.ts
+++ b/src/hlsBinaries.ts
@@ -133,10 +133,7 @@ async function callAsync(
 
 /** Gets serverExecutablePath and fails if it's not set.
  */
-async function findServerExecutable(
-  logger: Logger,
-  folder?: WorkspaceFolder
-): Promise<string> {
+async function findServerExecutable(logger: Logger, folder?: WorkspaceFolder): Promise<string> {
   let exePath = workspace.getConfiguration('haskell').get('serverExecutablePath') as string;
   logger.info(`Trying to find the server executable in: ${exePath}`);
   exePath = resolvePathPlaceHolders(exePath, folder);
@@ -200,7 +197,7 @@ export async function findHaskellLanguageServer(
   // first plugin initialization
   if (manageHLS !== 'GHCup' && (!context.globalState.get('pluginInitialized') as boolean | null)) {
     const promptMessage = `How do you want the extension to manage/discover HLS and the relevant toolchain?
-    
+
     Choose "Automatically" if you're in doubt.
     `;
 


### PR DESCRIPTION
The test-suite has its fair-share of issues and tests some things it is
not supposed to test. We remove tests that do not test functionality
that comes from vscode-haskell.

Overhaul CI to use only ghcup instead 'haskell/action/setup'