### PR TITLE
Change scope of serverExecutablePath to machine-overridable

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,10 +141,10 @@
           "markdownDescription": "An optional path where downloaded metadata will be stored. Check the default value [here](https://github.com/haskell/vscode-haskell#downloaded-binaries)"
         },
         "haskell.serverExecutablePath": {
-          "scope": "resource",
+          "scope": "machine-overridable",
           "type": "string",
           "default": "",
-          "markdownDescription": "Manually set a language server executable. Can be something on the $PATH or the full path to the executable itself. Works with `~,` `${HOME}` and `${workspaceFolder}`. **Deprecated scope**: This option will be set to `machine` scope in a future release, so it can be changed only globally, not per workspace."
+          "markdownDescription": "Manually set a language server executable. Can be something on the $PATH or the full path to the executable itself. Works with `~,` `${HOME}` and `${workspaceFolder}`."
         },
         "haskell.serverExtraArgs": {
           "scope": "resource",


### PR DESCRIPTION
Removes deprecation warning.
In accordance with https://github.com/haskell/vscode-haskell/issues/529#issuecomment-1177414902 don't deprecate the serverExecutablePath's scope, and set it to the standard 'machine-overridable'

Closes #529