### PR TITLE
Bump old hls version and upgrade test runner to macos-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-11, ubuntu-latest, windows-latest]
-        ghc: [8.10.4, 8.10.7, 9.0.2, 9.2.8, 9.4.5, 9.6.2]
+        ghc: [8.10.7, 9.0.2, 9.2.8, 9.4.7, 9.6.2]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -40,7 +40,7 @@ jobs:
           ghcup install ghc ${{matrix.ghc}}
           ghcup set ghc ${{matrix.ghc}}
 
-          ghcup install hls 1.4.0
+          ghcup install hls 2.2.0.0
           ghcup install hls latest
         shell: bash
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
         ghc: [8.10.7, 9.0.2, 9.2.8, 9.4.7, 9.6.2]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Following https://haskell-language-server.readthedocs.io/en/latest/support/ghc-version-support.html, HLS has dropped ghc-8.10.7 after hls-2.2.0.0, so we can replace 8.10.4 with 8.10.7 and hope it can make our test more stable...