### PR TITLE
Add `haskell.plugin.fourmolu.config.path` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -293,6 +293,12 @@
           "scope": "resource",
           "type": "boolean"
         },
+        "haskell.plugin.fourmolu.config.path": {
+          "default": "fourmolu",
+          "markdownDescription": "Set path to executable (for \"external\" mode)",
+          "scope": "resource",
+          "type": "string"
+        },
         "haskell.plugin.gadt.globalOn": {
           "default": true,
           "description": "Enables gadt plugin",


### PR DESCRIPTION
Companion to https://github.com/haskell/haskell-language-server/pull/3860. Shouldn't be merged until that is.

The added lines come from manually inspecting the output of `cabal run exe:haskell-language-server vscode-extension-schema`. Do we have a better automatic process for this (I'm sure it'd be fairly easy to script with `jq`, perhaps after an initial commit re-ordering things)?