### PR TITLE
Set the default URL source to the vanilla yaml to ensure we get the latest HLS binaries on time

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,8 +138,8 @@
         "haskell.metadataURL": {
           "scope": "resource",
           "type": "string",
-          "default": "",
-          "description": "An optional URL to override where ghcup checks for tool download info (usually at: https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-0.0.7.yaml)"
+          "default": "https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-vanilla-0.0.8.yaml",
+          "description": "An optional URL to override where ghcup checks for tool download info. We use the vanilla flavour to ensure the newest binaries are immediately available. Check the documentation at https://github.com/haskell/ghcup-metadata#using-the-metadata."
         },
         "haskell.releasesDownloadStoragePath": {
           "scope": "resource",


### PR DESCRIPTION
See the discussion in https://github.com/haskell/ghcup-metadata/pull/159
