### PR TITLE
Always set the cwd for the executable

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -225,7 +225,7 @@ async function activateServerForFolder(context: ExtensionContext, uri: Uri, fold
     };
   }
   const exeOptions: ExecutableOptions = {
-    cwd: folder ? undefined : path.dirname(uri.fsPath),
+    cwd: folder ? folder.uri.fsPath : path.dirname(uri.fsPath),
     env: { ...process.env, ...serverEnvironment },
   };
 


### PR DESCRIPTION
It seems this fixes the issue of #1010. It is currently completely a mystery to me why we didn't set this option before, and what the real issue is. Why does it seem only reproducible on MacOS.