### PR TITLE
Merge Pre release 2.5 into master

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog for vscode-haskell
 
+## 2.5.1
+
+- Includes changes of the 2.4.2 release
+
 ## 2.5.0
 
 - Add tracking of cabal files

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "haskell",
   "displayName": "Haskell",
   "description": "Haskell language support powered by the Haskell Language Server",
-  "version": "2.4.2",
+  "version": "2.5.1",
   "license": "MIT",
   "publisher": "haskell",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   },
   "activationEvents": [
     "onLanguage:haskell",
-    "onLanguage:literate haskell"
+    "onLanguage:literate haskell",
+    "onLanguage:cabal"
   ],
   "main": "./dist/extension",
   "contributes": {
@@ -49,6 +50,16 @@
           ".hs"
         ]
       },
+      {
+        "id": "cabal",
+        "aliases": [
+          "Cabal"
+        ],
+        "extensions": [
+          ".cabal"
+        ]
+      },
+
       {
         "id": "literate haskell",
         "aliases": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -259,6 +259,7 @@ async function activateServerForFolder(context: ExtensionContext, uri: Uri, fold
     documentSelector: [
       { scheme: 'file', language: 'haskell', pattern: pat },
       { scheme: 'file', language: 'literate haskell', pattern: pat },
+      { scheme: 'file', language: 'cabal', pattern: pat },
     ],
     synchronize: {
       // Synchronize the setting section 'haskell' to the server.


### PR DESCRIPTION
In accordance to our new branching policy, we are merging the pre-release back into master. The branch `release-2.4` has been created containing all changes up to f54fee6d6a70ea5f0174ffad49c4bda441895e49