### PR TITLE
Make js debugger work

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
       "runtimeExecutable": "${execPath}",
       "args": ["--extensionDevelopmentPath=${workspaceRoot}"],
       "sourceMaps": true,
-      "outFiles": ["${workspaceRoot}/out/src/**/*.js"],
+      "outFiles": ["${workspaceRoot}/dist/**/*.js"],
       "preLaunchTask": "npm: webpack"
     },
     {


### PR DESCRIPTION
Webpack output is in `dist` dir., but launch.json was pointing to wrong location.
This change makes vscode aware of sourcemap location, and fixes breakpoints in debugger